### PR TITLE
fix: Individual note head selection not displaying

### DIFF
--- a/src/components/Canvas/ChordGroup.tsx
+++ b/src/components/Canvas/ChordGroup.tsx
@@ -202,7 +202,6 @@ const ChordGroup = ({
             isSelected={isSelected || isAnyNoteHovered}
             isGhost={isGhost}
             accidentalGlyph={accidentalGlyph}
-            color={groupColor}
             handlers={handlers}
           />
         );


### PR DESCRIPTION
## Summary
Fixes #34 - Individual note head selection within chords was not displaying.

## Root Cause
`ChordGroup.tsx` passed `color={groupColor}` to each `Note` component, which overrides the individual `isSelected` highlighting logic. The `groupColor` only changed to accent when the *entire* chord was selected, ignoring individual note selections.

## Fix
Remove the `color` prop from `Note`, letting each note determine its own color based on its `isSelected` prop.

## Testing
- Created a chord with multiple notes
- Clicking individual note heads now correctly highlights just that note
- Full chord selection still highlights all notes