### PR TITLE
fix: Dragging single notes to change pitch not working

### DIFF
--- a/src/hooks/useScoreInteraction.ts
+++ b/src/hooks/useScoreInteraction.ts
@@ -174,7 +174,7 @@ export const useScoreInteraction = ({ scoreRef, selection, onUpdatePitch, onSele
             document.removeEventListener('mouseup', handleMouseUp);
             document.body.style.cursor = 'default';
         };
-    }, [dragState, scoreRef, onUpdatePitch]);
+    }, [dragState, scoreRef, onUpdatePitch, selection]);
 
     return {
         dragState,

--- a/src/utils/commandHelpers.ts
+++ b/src/utils/commandHelpers.ts
@@ -106,7 +106,7 @@ export const updateNote = (
     updateFn: (note: Note) => boolean | void
 ): Score => {
     return updateEvent(score, staffIndex, measureIndex, eventId, (event) => {
-        const noteIndex = event.notes.findIndex(n => n.id === noteId);
+        const noteIndex = event.notes.findIndex(n => String(n.id) === String(noteId));
         if (noteIndex === -1) return false;
 
         const newNotes = [...event.notes];


### PR DESCRIPTION
## Summary
Fixes #9 - Dragging notes up/down with the mouse to change pitch was not working for single-note events.

## Root Cause
**Type mismatch** in note ID comparison:
- Note IDs are created as **numbers** (`Date.now()`)
- But passed through the drag handler as **strings** (`String(n.id)`)
- `findIndex` in `updateNote` used strict equality (`===`), which failed for `1765730391350 === '1765730391350'`

Multi-note chords worked because they used a different code path (selection-based lookup).

## Changes

### `src/utils/commandHelpers.ts`
- Fixed `updateNote` to use `String()` comparison for type-safe noteId matching

### `src/hooks/useScoreInteraction.ts`
- Added `selection` to useEffect dependencies for correctness (was already used inside the effect)

## Testing
1. Select and drag a single note up/down ✅ Now works
2. Select and drag a chord (2+ notes) up/down ✅ Still works
3. Multi-select notes and drag ✅ Still works