### PR TITLE
fix: Multi-select drag only moved targeted event

### DIFF
--- a/src/hooks/useScoreInteraction.ts
+++ b/src/hooks/useScoreInteraction.ts
@@ -101,8 +101,11 @@ export const useScoreInteraction = ({ scoreRef, selection, onUpdatePitch, onSele
             initialPitches
         });
         
-        // Optimistic selection update on mouse down
-        onSelectNote(measureIndex, eventId, noteId, staffIndex, isMulti, selectAllInEvent, isShift);
+        // Only update selection if note is NOT already selected
+        // (dragging an already-selected note should preserve the current selection)
+        if (!isNoteInSelection) {
+            onSelectNote(measureIndex, eventId, noteId, staffIndex, isMulti, selectAllInEvent, isShift);
+        }
     }, [onSelectNote, selection, scoreRef]);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes #49 - When multiple notes were selected, dragging any note would deselect all but the targeted event.

## Root Cause
In handleDragStart, onSelectNote was called on every drag start, resetting the selection even when the note was already part of a multi-selection.

## Fix
Only call onSelectNote if the note is NOT already selected. This preserves the current selection when dragging already-selected notes.

## Testing
- Select multiple notes across different events
- Drag one of the selected notes up/down
- All selected notes move together