### PR TITLE
fix: Improve dark theme accent contrast

### DIFF
--- a/src/themes.ts
+++ b/src/themes.ts
@@ -16,7 +16,7 @@ export const COLORS = {
   slate500: 'hsla(215, 16%, 47%, 1.00)',
   slate400: 'hsla(215, 20%, 65%, 1.00)',
   slate200: '#e2e8f0',
-  teal: '#20B2AA', 
+  teal: '#1DA59C', // #1DA59C
   
   // Blue (Cool)
   blue950: '#0f172a',


### PR DESCRIPTION
## Summary

Darkens the teal accent color from `#20B2AA` to `#1DA59C` for better contrast against dark theme text on buttons.

## Changes

- **`src/themes.ts`**: Updated `COLORS.teal` from `#20B2AA` to `#1DA59C`

## Accessibility

This change improves WCAG 2.1 compliance by increasing the contrast ratio between accent-colored button backgrounds and dark theme text.

Closes #13