### PR TITLE
fix: Prevent crash when entering rests

### DIFF
--- a/src/components/Canvas/Staff.tsx
+++ b/src/components/Canvas/Staff.tsx
@@ -135,6 +135,9 @@ const Staff: React.FC<StaffProps> = ({
       measure.events.forEach((event, eIndex: number) => {
         const eventX = currentMeasureX + layout.eventPositions[event.id];
         event.notes.forEach((note: any, nIndex: number) => {
+          // Skip rest notes (which have null pitch) - they can't have ties
+          if (note.pitch === null) return;
+          
           allNotes.push({
             measureIndex: mIndex,
             eventIndex: eIndex,

--- a/src/engines/layout/positioning.ts
+++ b/src/engines/layout/positioning.ts
@@ -102,7 +102,10 @@ const CLEF_REFERENCE: Record<string, { pitch: string; offset: number }> = {
  * @param clef - Clef context ('treble' or 'bass')
  * @returns Y offset in pixels relative to CONFIG.baseY
  */
-export const getOffsetForPitch = (pitch: string, clef: string = 'treble'): number => {
+export const getOffsetForPitch = (pitch: string | null | undefined, clef: string = 'treble'): number => {
+  // Handle null/undefined pitch (e.g., rest notes)
+  if (!pitch) return 0;
+  
   const normalizedPitch = getStaffPitch(pitch);
   
   // Try lookup first for common pitches (faster)


### PR DESCRIPTION
## Problem
The app crashed when attempting to enter a rest (TypeError: Cannot read properties of null (reading 'match')).

## Root Cause
Rest notes have `pitch: null`, but the tie rendering code in `Staff.tsx` iterated over ALL notes (including rest notes) and called `getOffsetForPitch(note.pitch, clef)` with `null`.

## Solution
1. **Staff.tsx**: Skip rest notes (null pitch) in the `renderTies` loop — rests can't have ties anyway
2. **positioning.ts**: Add defensive null-check in `getOffsetForPitch` for robustness

## Testing
- Build passed ✅
- 320/320 tests passed ✅
- Manual testing: rest entry now works without crash

Closes #57