### PR TITLE
fix: Allow CMD/CTRL+R to refresh page

### DIFF
--- a/src/hooks/handlers/handleMutation.ts
+++ b/src/hooks/handlers/handleMutation.ts
@@ -42,9 +42,10 @@ export const handleMutation = (
     }
 
     // REST TOGGLE (R key)
+    // Skip if CMD/CTRL is held (allow browser refresh with CMD+R / CTRL+R)
     // - Always toggles inputMode
     // - When selection exists, also converts notes↔rests
-    if (e.key === 'r' || e.key === 'R') {
+    if ((e.key === 'r' || e.key === 'R') && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         
         // Always toggle the input mode


### PR DESCRIPTION
## Problem
Pressing CMD+R (Mac) or CTRL+R (Windows) triggered the rest toggle instead of refreshing the page.

## Solution
Added modifier key check to the R key handler, allowing browser shortcuts to pass through.

Closes #60