### PR TITLE
fix: Pause button properly suspends and resumes playback

### DIFF
--- a/src/hooks/handlers/handlePlayback.ts
+++ b/src/hooks/handlers/handlePlayback.ts
@@ -33,13 +33,22 @@ export const handlePlayback = (
         } else if (e.shiftKey) {
              playScore(lastPlayStart.measureIndex, lastPlayStart.eventIndex);
         } else {
-             if (isPlaying) stopPlayback();
-             else {
-                 if (selection.measureIndex !== null && selection.eventId) {
+             if (isPlaying) {
+                 playback.pausePlayback();
+             } else {
+                 // RESUME from NEXT event if paused (position exists)
+                 if (playback.playbackPosition && playback.playbackPosition.measureIndex !== null) {
+                     const resumeQuant = (playback.playbackPosition.quant ?? -1) + 1;
+                     playScore(playback.playbackPosition.measureIndex, resumeQuant);
+                 } 
+                 // START from selection if stopped
+                 else if (selection.measureIndex !== null && selection.eventId) {
                     const m = measures[selection.measureIndex];
                     const eIdx = m.events.findIndex((evt: any) => evt.id === selection.eventId);
                     playScore(selection.measureIndex, eIdx !== -1 ? eIdx : 0);
-                 } else {
+                 } 
+                 // START from beginning
+                 else {
                     playScore(0, 0);
                  }
              }


### PR DESCRIPTION
## Problem
The pause button (and Spacebar) was restarting playback from the beginning when resumed, instead of continuing from where it paused.

## Solution
1. **usePlayback.ts**: Added `pausePlayback` function that stops audio but retaining the `playbackPosition` state. Updated `handlePlayToggle` to use this for pausing, and to check for an existing positions when resuming.
2. **handlePlayback.ts**: Updated the Spacebar handler to mirror this behavior (Pause if playing, Resume if paused/valid position, Start from Selection/0 if stopped).

## Changes
- `src/hooks/usePlayback.ts`: Added `pausePlayback`, updated `handlePlayToggle`.
- `src/hooks/handlers/handlePlayback.ts`: Updated logic to support Pause/Resume flow.

Closes #64