### PR TITLE
Prepare for npm publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to RiffScore will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.0.0-alpha.2] - 2025-12-15
+
+### Fixed
+
+#### Playback
+- **Pause/resume now works correctly** - Pressing pause and then play resumes from the current position instead of restarting from the beginning ([#64](https://github.com/joekotvas/RiffScore/issues/64))
+
+#### Note Entry & Editing
+- **Rest entry no longer crashes the app** - Fixed a regression where attempting to enter a rest would cause the application to crash ([#57](https://github.com/joekotvas/RiffScore/issues/57))
+- **Browser refresh shortcut no longer triggers rest toggle** - CMD/CTRL+R now correctly refreshes the page without toggling rest mode ([#60](https://github.com/joekotvas/RiffScore/issues/60))
+- **Arrow navigation after note entry works correctly** - Left arrow key no longer skips the newly entered note after committing with Enter ([#8](https://github.com/joekotvas/RiffScore/issues/8))
+
+#### Mouse Interaction
+- **Vertical note dragging restored** - Dragging notes up/down with the mouse to change pitch now works correctly again ([#9](https://github.com/joekotvas/RiffScore/issues/9))
+- **Multi-note drag selection moves all selected notes** - Dragging a selection of notes now moves the entire selection, not just the targeted event ([#49](https://github.com/joekotvas/RiffScore/issues/49))
+- **Note pitch clamping during drag** - Dragging notes past the visible staff range no longer allows invalid pitches ([#51](https://github.com/joekotvas/RiffScore/issues/51))
+
+#### Selection
+- **Individual note head selection visible again** - Fixed a regression where clicking on a single note head would not display the selection highlight ([#34](https://github.com/joekotvas/RiffScore/issues/34))
+- **Shift+Arrow and Shift+Click now work for rests** - Extended range selection now correctly includes rest events ([#33](https://github.com/joekotvas/RiffScore/issues/33))
+- **Lasso selection highlights notes during drag** - Notes now visually highlight as the lasso rectangle passes over them ([#32](https://github.com/joekotvas/RiffScore/issues/32))
+
+#### UI & Theming
+- **Auto-scroll behavior improved** - Scrolling is now less aggressive, allowing users to review other parts of the score without the viewport jumping back ([#14](https://github.com/joekotvas/RiffScore/issues/14))
+- **Dark theme button contrast fixed** - Improved color contrast for accent buttons in dark mode for better accessibility ([#13](https://github.com/joekotvas/RiffScore/issues/13))
+- **Footer theme syncs correctly** - Footer no longer stays in light theme when switching back to dark theme ([#3](https://github.com/joekotvas/RiffScore/issues/3))
+- **Key signature menu reorganized** - Menu now includes all key signatures in a logical order (circle of fifths) ([#12](https://github.com/joekotvas/RiffScore/issues/12))
+- **Help panel shortcuts updated** - Keyboard shortcuts in the help panel now reflect the current keybindings ([#59](https://github.com/joekotvas/RiffScore/issues/59))
+
+### Changed
+- **Build artifacts removed from version control** - The `dist/` directory is no longer tracked in Git; it is generated during the build process ([#53](https://github.com/joekotvas/RiffScore/issues/53))
+
+### Documentation
+- **Added CHANGELOG.md** - Introduced a changelog following the [Keep a Changelog](https://keepachangelog.com/) format to document all notable changes ([#69](https://github.com/joekotvas/RiffScore/issues/69))
+- **Architecture documentation audited and updated** - Comprehensive review and updates to `ARCHITECTURE.md` and `INTERACTION.md` to reflect current codebase structure ([#67](https://github.com/joekotvas/RiffScore/issues/67))
+- **File structure documentation corrected** - Updated `ARCHITECTURE.md` to match the current directory layout after repository restructuring ([#4](https://github.com/joekotvas/RiffScore/issues/4))
+
+## [1.0.0-alpha.1]
+
+Initial alpha release with core sheet music editing functionality:
+
+- Grand staff, treble clef, and bass clef configurations
+- Note entry via mouse click and keyboard
+- Key signature and time signature selection
+- Playback with Tone.js
+- Undo/redo support
+- Theme selection (dark, light, cool, warm)
+- SMuFL-compliant engraving with Bravura font

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Joseph Kotvas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riffscore",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "An intuitive, embeddable sheet music editor for React",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -70,10 +70,14 @@
     "editor",
     "component"
   ],
-  "author": "",
+  "author": "Joseph Kotvas",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "git+https://github.com/joekotvas/RiffScore.git"
+  },
+  "homepage": "https://github.com/joekotvas/RiffScore#readme",
+  "bugs": {
+    "url": "https://github.com/joekotvas/RiffScore/issues"
   }
 }


### PR DESCRIPTION
## Summary

Prepares the RiffScore package for initial npm publication.

Closes #69

## Changes

### New Files
- **CHANGELOG.md** - Comprehensive changelog documenting all 18 resolved issues for alpha.2 release
- **LICENSE** - MIT License file (was missing, required for npm publish)

### Updated Files
- **package.json**
  - Version bumped from `1.0.0-alpha.1` to `1.0.0-alpha.2`
  - Author set to "Joseph Kotvas"
  - Repository, homepage, and bugs URLs added

## Changelog Highlights (alpha.2)

### Fixed
- Pause/resume playback now works correctly
- Rest entry no longer crashes the app
- Vertical note dragging restored
- Multi-note drag selection moves all selected notes
- Individual note head selection visible again
- Auto-scroll behavior improved
- Key signature menu reorganized
- And 8 more bug fixes...

### Documentation
- Added CHANGELOG.md
- Architecture documentation audited and updated

## Verification
- ✅ Build succeeds
- ✅ Package contents verified (572.5 KB compressed)
- ⚠️ 4 pre-existing test failures (unrelated to these changes - stale test mocks)
