### PR TITLE
Fix stale test mocks and API mismatches

### DIFF
--- a/src/__tests__/Interaction.test.tsx
+++ b/src/__tests__/Interaction.test.tsx
@@ -24,10 +24,6 @@ jest.mock('../components/Toolbar/Toolbar', () => {
   });
 });
 
-jest.mock('../components/Panels/OutputPanel', () => () => (
-  <div data-testid="output-panel">Mock Output Panel</div>
-));
-
 // Mock Tone.js
 jest.mock('../engines/toneEngine', () => ({
   playNote: jest.fn(),

--- a/src/__tests__/MultiSelect.test.tsx
+++ b/src/__tests__/MultiSelect.test.tsx
@@ -9,7 +9,6 @@ import { createDefaultScore } from '@/types';
 jest.mock('../components/Toolbar/Toolbar', () => (props: any) => (
   <div data-testid="score-toolbar" />
 ));
-jest.mock('../components/Panels/OutputPanel', () => () => <div data-testid="output-panel" />);
 jest.mock('../hooks/usePlayback', () => ({
   usePlayback: () => ({
     isPlaying: false,

--- a/src/__tests__/Smoke.test.tsx
+++ b/src/__tests__/Smoke.test.tsx
@@ -22,13 +22,6 @@ jest.mock('../components/Toolbar/Toolbar', () => {
   });
 });
 
-// Mock OutputPanel
-jest.mock('../components/Panels/OutputPanel', () => {
-  return function MockOutputPanel() {
-    return <div data-testid="output-panel">Mock Output Panel</div>;
-  };
-});
-
 // Mock hooks
 jest.mock('../hooks/usePlayback', () => ({
   usePlayback: () => ({

--- a/src/__tests__/handlePlayback.test.ts
+++ b/src/__tests__/handlePlayback.test.ts
@@ -9,8 +9,10 @@ describe('handlePlayback', () => {
     mockPlayback = {
       playScore: jest.fn(),
       stopPlayback: jest.fn(),
+      pausePlayback: jest.fn(),
       isPlaying: false,
       lastPlayStart: { measureIndex: 0, eventIndex: 0 },
+      playbackPosition: { measureIndex: null, quant: null },
     };
     mockScore = {
       staves: [
@@ -55,7 +57,7 @@ describe('handlePlayback', () => {
     // Stop playback
     mockPlayback.isPlaying = true;
     handlePlayback(mockEvent, mockPlayback, selection, mockScore);
-    expect(mockPlayback.stopPlayback).toHaveBeenCalled();
+    expect(mockPlayback.pausePlayback).toHaveBeenCalled();
   });
 
   test('should ignore other keys', () => {


### PR DESCRIPTION
## Summary

Fixes 4 failing test suites caused by stale mocks and API changes.

Closes #71

## Changes

### Removed stale `OutputPanel` mocks
The `OutputPanel` component was removed from the codebase, but test mocks still referenced it:
- `Smoke.test.tsx`
- `MultiSelect.test.tsx`
- `Interaction.test.tsx`

### Updated playback API in test mock
`handlePlayback.test.ts` was updated to include `pausePlayback()` in the mock (added in #64 for pause/resume functionality).

## Verification

✅ All 34 test suites pass
✅ 330 tests pass (was 319 passing before)
