### PR TITLE
chore: Clean up build warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css"
   },

--- a/src/__tests__/MusicService.test.ts
+++ b/src/__tests__/MusicService.test.ts
@@ -3,14 +3,11 @@ import {
   getMidi,
   midiToPitch,
   getStaffPitch,
-  getKeyInfo,
   getScaleNotes,
   getKeyAlteration,
   needsAccidental,
   applyKeySignature,
   movePitchVisual,
-  getInterval,
-  getSemitones,
   getAccidentalGlyph,
   getScaleDegree,
 } from '@/services/MusicService';
@@ -72,35 +69,6 @@ describe('MusicService', () => {
       it('round-trips correctly', () => {
         const pitch = 'E5';
         expect(midiToPitch(getMidi(pitch))).toBe(pitch);
-      });
-    });
-
-    describe('getInterval', () => {
-      it('calculates perfect fifth', () => {
-        expect(getInterval('C4', 'G4')).toBe('5P');
-      });
-
-      it('calculates major third', () => {
-        expect(getInterval('C4', 'E4')).toBe('3M');
-      });
-
-      it('calculates descending intervals', () => {
-        expect(getInterval('G4', 'C4')).toBe('-5P');
-      });
-    });
-
-    describe('getSemitones', () => {
-      it('returns 7 semitones for perfect fifth', () => {
-        expect(getSemitones('5P')).toBe(7);
-      });
-
-      it('returns 4 semitones for major third', () => {
-        expect(getSemitones('3M')).toBe(4);
-      });
-
-      it('returns 0 for invalid interval', () => {
-        const result = getSemitones('invalid');
-        expect(result === 0 || isNaN(result)).toBe(true);
       });
     });
   });

--- a/src/services/MusicService.ts
+++ b/src/services/MusicService.ts
@@ -6,7 +6,7 @@
  * "Visual Pitch" (Staff positioning).
  */
 
-import { Note, Key, Interval } from 'tonal';
+import { Note, Key } from 'tonal';
 import { ACCIDENTALS } from '@/constants/SMuFL';
 
 // --- Constants ---
@@ -25,13 +25,6 @@ export const getMidi = (pitch: string): number => Note.midi(pitch) ?? 60;
 
 /** Returns scientific notation from MIDI (e.g. 60 -> "C4"). */
 export const midiToPitch = (midi: number): string => Note.fromMidi(midi) ?? 'C4';
-
-/** Returns semitones for an interval (e.g., "P5" -> 7). */
-export const getSemitones = (interval: string): number => Interval.semitones(interval) ?? 0;
-
-/** Returns interval distance between two pitches (e.g. "C4", "G4" -> "P5"). */
-export const getInterval = (from: string, to: string): string =>
-  Interval.distance(from, to) ?? 'P1';
 
 // ============================================================================
 // 2. THEORY (Keys & Scales)


### PR DESCRIPTION
## Summary

Fixes build warnings identified in issue #73.

## Changes

### 1. Package exports `types` condition order
Moved `types` to the first position in the exports conditions, as required by Node.js for TypeScript resolution.

### 2. Removed unused `Interval` import
Removed the `Interval` import from `tonal` and deleted the `getSemitones` and `getInterval` functions that were only used in tests but not exported from the library bundle.

## Verification

- ✅ Build completes with no warnings
- ✅ All 324 tests pass

Closes #73