### PR TITLE
Fix: Score title scales with zoom

### DIFF
--- a/src/components/Layout/ScoreEditor.tsx
+++ b/src/components/Layout/ScoreEditor.tsx
@@ -240,6 +240,7 @@ const ScoreEditorContent = ({
             commit={titleEditor.commit}
             inputRef={titleEditor.inputRef}
             theme={theme}
+            scale={scale}
           />
         </div>
 

--- a/src/components/Layout/ScoreTitleField.tsx
+++ b/src/components/Layout/ScoreTitleField.tsx
@@ -12,6 +12,7 @@ interface ScoreTitleFieldProps {
     text: string;
     border: string;
   };
+  scale?: number;
 }
 
 /**
@@ -26,7 +27,11 @@ export function ScoreTitleField({
   commit,
   inputRef,
   theme,
+  scale = 1,
 }: ScoreTitleFieldProps) {
+  // Base font size is 1.875rem (text-3xl), scaled by the zoom factor
+  const fontSize = `calc(1.875rem * ${scale})`;
+
   if (isEditing) {
     return (
       <input
@@ -35,8 +40,8 @@ export function ScoreTitleField({
         onChange={(e) => setBuffer(e.target.value)}
         onBlur={commit}
         onKeyDown={(e) => e.key === 'Enter' && commit()}
-        className="ScoreTitleFieldInput font-bold font-serif text-3xl px-1 mx-[1.5rem] py-0 rounded outline-none bg-transparent"
-        style={{ color: theme.text, borderColor: theme.border, borderWidth: '1px' }}
+        className="ScoreTitleFieldInput font-bold font-serif px-1 mx-[1.5rem] py-0 rounded outline-none bg-transparent"
+        style={{ color: theme.text, borderColor: theme.border, borderWidth: '1px', fontSize }}
       />
     );
   }
@@ -44,8 +49,8 @@ export function ScoreTitleField({
   return (
     <h2
       onClick={() => setIsEditing(true)}
-      className="ScoreTitleField font-bold font-serif text-3xl px-[1.75rem] py-0 rounded hover:bg-white/10 cursor-pointer transition-colors inline-block"
-      style={{ color: theme.text, borderColor: 'transparent', borderWidth: '1px' }}
+      className="ScoreTitleField font-bold font-serif px-[1.75rem] py-0 rounded hover:bg-white/10 cursor-pointer transition-colors inline-block"
+      style={{ color: theme.text, borderColor: 'transparent', borderWidth: '1px', fontSize }}
     >
       {title}
     </h2>


### PR DESCRIPTION
## Summary
Fixes #1 - Score title now scales proportionally with the score content when zoom is adjusted.

## Changes
- **ScoreTitleField.tsx**: Added `scale` prop with dynamic `fontSize` styling (`calc(1.875rem * scale)`)
- **ScoreEditor.tsx**: Passed `scale` prop to `<ScoreTitleField>`

## Testing
Verified manually in demo app at ~200% and ~50% zoom - title scales correctly.