### PR TITLE
fix: address remaining any types in types.ts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,7 @@ export const getActiveStaff = (score: Score, staffIndex: number = 0): Staff => {
  * Migrates an old-format score to the new staves model
  * Also syncs top-level legacy fields (measures, keySignature, clef) back to staves[0]
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Accepts unknown legacy score formats
 export const migrateScore = (oldScore: any): Score => {
   // If already in new format with staves
   if (oldScore.staves && Array.isArray(oldScore.staves)) {
@@ -168,7 +169,7 @@ export const migrateScore = (oldScore: any): Score => {
 export interface Melody {
   id: string;
   title: string;
-  score: any;
+  score: Score;
 }
 
 // ========== SELECTION ==========


### PR DESCRIPTION
## Summary

Follow-up cleanup after merging PR #80.

## Changes

- **Melody.score**: Changed from `any` to `Score`
- **migrateScore**: Added eslint-disable comment (intentional `any` for legacy format migration)

## Verification

- ✅ 354/354 tests pass