### PR TITLE
refactor(layout): measure-relative X positioning (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 - **Release Workflow Documentation**: New [RELEASE_WORKFLOW.md](docs/RELEASE_WORKFLOW.md) with step-by-step checklist for version releases, including verification, changelog updates, GitHub releases, and LinkedIn announcements.
+- **ADR-016: Measure-Relative X Positioning**: Design decision documenting the coordinate system migration for system breaks support. See [ADR-016](docs/adr/016-measure-relative-x.md).
 
 ### Changed
 - **Chord Input UX ([#220](https://github.com/joekotvas/riffscore/issues/220))**:
   - Raised chord baseline height for better visual separation from staff.
   - Simplified placeholder text to "Cm7".
   - Tab/Shift+Tab now stays in edit mode when at the last/first chord position instead of closing the editor.
+
+### Refactoring
+- **Measure-Relative X Positioning ([#204](https://github.com/joekotvas/riffscore/issues/204))**: Complete migration to measure-relative coordinates to prepare for system breaks (multi-line rendering).
+  - **ScoreLayout API**: `getX({ measure, quant })` now returns measure-relative X; `getX.measureOrigin({ measure })` returns absolute origin.
+  - **ChordSymbol Data Model**: Chords now use `{ measure, quant }` instead of global quant. Old scores auto-migrate.
+  - **Layout Types**: `NoteLayout.x` and `EventLayout.x` renamed to `localX` (measure-relative).
+  - **Cursor & Hit Detection**: Updated `useCursorLayout`, `ScoreCanvas`, and `useDragToSelect` to use new coordinate system.
+  - **Deprecations**: `quantToX()` and `xToNearestQuant()` in `coordinateUtils.ts` deprecated in favor of measure-aware lookups.
+  - See [migration spec](docs/migration/measure-relative-x-spec.md) for full details.
 
 ## [1.0.0-alpha.9] - 2026-02-13
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -44,7 +44,8 @@ Key patterns:
 | `src/types.ts` | Score, Staff, Measure, Event, Note, Selection |
 | `src/api.types.ts` | MusicEditorAPI interface |
 | `src/componentTypes.ts` | Component prop types |
-| `src/config.ts` | Layout constants |
+| `src/config.ts` | Centralized layout tuning (`CONFIG.toolbar`, `CONFIG.header`, `CONFIG.chordTrack`) |
+| `src/constants.ts` | Music theory & rendering (`LAYOUT`, `STEM`, `BEAMING`, `NOTE_TYPES`) |
 
 ### State Management
 | File | Purpose |

--- a/docs/CODING_PATTERNS.md
+++ b/docs/CODING_PATTERNS.md
@@ -174,6 +174,73 @@ See also: [docs/ARCHITECTURE.md](./ARCHITECTURE.md)
 
 ---
 
+## 2.5 Constants & Configuration
+
+All tunable values must be centralized. **Never scatter magic numbers across files.**
+
+### Where Constants Live
+
+| File | Purpose | Examples |
+|------|---------|----------|
+| `src/config.ts` | Layout & UI tuning | `baseY`, `staffSpacing`, `toolbar.iconSize`, `header.*`, `chordTrack.*` |
+| `src/constants.ts` | Music theory & rendering | `LAYOUT`, `STEM`, `BEAMING`, `TUPLET`, `NOTE_TYPES`, `KEY_SIGNATURES` |
+
+### Using Constants
+
+**Pattern:** Import CONFIG, derive local constants for repeated use:
+
+```typescript
+// ✅ Good: Centralized, short local name for readability
+import { CONFIG } from '@/config';
+
+const ICON_SIZE = CONFIG.toolbar.iconSize;
+
+const MyIcon = () => (
+  <svg width={ICON_SIZE} height={ICON_SIZE}>...</svg>
+);
+```
+
+```typescript
+// ✅ Good: Use LAYOUT for rendering constants
+import { LAYOUT } from '@/constants';
+
+const ACCIDENTAL_PADDING = LAYOUT.ACCIDENTAL_PADDING;
+```
+
+```typescript
+// ❌ Bad: Magic number scattered in component
+const ICON_SIZE = 20;  // Where did this come from?
+```
+
+### CONFIG Structure
+
+```typescript
+CONFIG = {
+  // Core layout
+  lineHeight: 12,
+  baseY: 80,
+  staffSpacing: 120,
+
+  // Feature-specific tuning (grouped)
+  toolbar: { iconSize: 20 },
+  header: { clefWidth: 40, keySigStartX: 45, ... },
+  chordTrack: { minDistanceFromStaff: 40, paddingAboveNotes: 20, minY: 0 },
+
+  // Debug flags
+  debug: { enabled: true, ... }
+}
+```
+
+### Adding New Constants
+
+1. **Identify the category** (layout, toolbar, rendering, feature-specific)
+2. **Add to appropriate file** (`config.ts` for tuning, `constants.ts` for music theory/rendering)
+3. **Group related values** in nested objects (e.g., `CONFIG.chordTrack.*`)
+4. **Update imports** in consuming files
+5. **Document** with JSDoc comments
+
+---
+
 ## 3. Core Utilities
 
 ### ID Generation

--- a/docs/LAYOUT_ENGINE.md
+++ b/docs/LAYOUT_ENGINE.md
@@ -10,18 +10,94 @@
 
 ## 1. Overview
 
-The layout engine transforms **Score data** into **visual coordinates** for SVG rendering. It consists of 8 modules in `src/engines/layout/`:
+The layout engine transforms **Score data** into **visual coordinates** for SVG rendering. It consists of modules in `src/engines/layout/`:
 
 | Module | Purpose |
 |--------|---------|
 | `index.ts` | Re-exports all layout functions |
-| `types.ts` | Layout type definitions |
+| `types.ts` | Layout type definitions (`ScoreLayout`, `YBounds`) |
+| `scoreLayout.ts` | **Single source of truth** for all positions |
 | `positioning.ts` | Pitch → Y coordinate mapping |
 | `measure.ts` | Event positions, hit zones |
 | `beaming.ts` | Beam groups and angles |
 | `tuplets.ts` | Tuplet bracket positioning |
 | `stems.ts` | Stem lengths and directions |
 | `system.ts` | Multi-staff synchronization |
+| `coordinateUtils.ts` | SVG coordinate utilities |
+
+---
+
+## 1.5 ScoreLayout: Single Source of Truth
+
+The `scoreLayout.ts` module provides `calculateScoreLayout(score)`, which returns a `ScoreLayout` object containing all position data and accessor functions.
+
+### ScoreLayout Interface
+
+```typescript
+interface ScoreLayout {
+  staves: StaffLayout[];
+  notes: Record<string, NoteLayout>;
+  events: Record<string, EventLayout>;
+
+  // X coordinate accessor
+  getX: (quant: number) => number;
+
+  // Y coordinate accessors
+  getY: {
+    content: YBounds;                           // { top, bottom }
+    system: (index: number) => YBounds | null;  // System bounds
+    staff: (index: number) => YBounds | null;   // Staff bounds
+    notes: (quant?: number) => YBounds;         // Note extent (collision)
+    pitch: (pitch: string, staffIndex: number) => number | null;
+  };
+}
+```
+
+### Using getX for Horizontal Positioning
+
+```typescript
+// Get X position for any quant (beat position)
+const x = layout.getX(48);  // X for beat 3 in 4/4
+
+// Works for chords, cursors, lyrics, dynamics — any quant-based element
+```
+
+### Using getY for Vertical Positioning
+
+```typescript
+// Staff bounds (top line to bottom line)
+const staffBounds = layout.getY.staff(0);  // { top: 80, bottom: 128 }
+
+// System bounds (all staves combined)
+const systemBounds = layout.getY.system(0);  // { top: 80, bottom: 248 }
+
+// Note extent for collision avoidance
+const noteExtent = layout.getY.notes();       // System-wide
+const atQuant = layout.getY.notes(48);        // At specific beat
+
+// Pitch positioning (clef-aware)
+const y = layout.getY.pitch('C4', 0);  // Y for C4 on staff 0
+```
+
+### Forward-Flow Y Positioning
+
+Y positions flow from top to bottom. Each element derives its position from elements above:
+
+```
+Y=0 (top of canvas)
+  ↓
+ChordTrack (above staves, avoiding notes)
+  ↓
+System 0
+  ├── Staff 0 (treble)
+  │     ↓ Notes (ledger lines up/down)
+  ├── Staff 1 (bass)
+  │     ↓ Notes
+  ↓
+Future: Lyrics, Dynamics, Pedaling (below staves)
+```
+
+> See [ADR-015: Forward-Flow Y Positioning](./adr/015-forward-flow-y-positioning.md) for design rationale.
 
 ---
 
@@ -198,12 +274,15 @@ flowchart TD
 
 | Function | File | Purpose |
 |----------|------|---------|
-| `calculateMeasureLayout` | measure.ts | Event X positions |
-| `calculateChordLayout` | measure.ts | Note Y + accidentals |
+| `calculateScoreLayout` | scoreLayout.ts | **Main entry point** — returns `ScoreLayout` with `getX`/`getY` |
+| `calculateMeasureLayout` | measure.ts | Event X positions within a measure |
+| `calculateChordLayout` | positioning.ts | Note offsets for second intervals |
 | `calculateBeamingGroups` | beaming.ts | Group notes for beaming |
 | `calculateStemDirection` | stems.ts | Up or down |
 | `calculateTupletBracket` | tuplets.ts | Bracket positioning |
-| `pitchToY` | positioning.ts | Pitch → Y coordinate |
+| `getOffsetForPitch` | positioning.ts | Pitch → Y offset (clef-aware) |
+| `clientToSvg` | coordinateUtils.ts | Client coords → SVG coords |
+| `xToNearestQuant` | coordinateUtils.ts | X position → nearest quant |
 
 ---
 

--- a/docs/LAYOUT_ENGINE.md
+++ b/docs/LAYOUT_ENGINE.md
@@ -300,7 +300,7 @@ flowchart TD
 | `calculateTupletBracket` | tuplets.ts | Bracket positioning |
 | `getOffsetForPitch` | positioning.ts | Pitch → Y offset (clef-aware) |
 | `clientToSvg` | coordinateUtils.ts | Client coords → SVG coords |
-| `xToNearestQuant` | coordinateUtils.ts | X position → nearest quant |
+| ~~`xToNearestQuant`~~ | coordinateUtils.ts | ~~X position → nearest quant~~ (deprecated, use measure-aware lookup) |
 
 ---
 

--- a/docs/adr/015-forward-flow-y-positioning.md
+++ b/docs/adr/015-forward-flow-y-positioning.md
@@ -1,0 +1,155 @@
+# ADR-015: Forward-Flow Y Positioning API
+
+> **Principle**: Single Source of Truth, Forward-Flow Design
+> **Status**: Proposed
+> **Date**: 2026-02-13
+> **Spec**: [y-positioning-spec.md](../migration/y-positioning-spec.md)
+
+## Context
+
+Vertical positioning logic is scattered across components:
+
+- `ScoreCanvas.tsx`: computes `chordTrackY`, builds `noteYByQuant` map (~45 lines)
+- `ChordTrack.tsx`: computes `getChordYOffset` collision logic (~20 lines)
+- Future elements (lyrics, dynamics, pedal) would duplicate this pattern
+
+This fragmentation causes:
+1. **Fragility**: Adjusting title-to-score spacing broke cursor hit detection
+2. **Duplication**: Each floating element reimplements Y calculations
+3. **Backwards references**: Components reference each other's spacing constants
+4. **Cognitive load**: Understanding positioning requires reading multiple files
+
+## Decision
+
+Add a `getY` API to `ScoreLayout` using **forward-flow computation** with **five accessor functions**.
+
+### Terminology
+
+- **System**: One line of music on a page (all staves rendered horizontally together)
+- **System break**: A line break where music wraps to the next system
+- **Staff**: A single 5-line pentagram within a system
+
+### Forward-Flow Principle
+
+Top-level positions flow from Y=0 downward. Each element derives from the previous:
+
+```
+Y=0 → Header → Title → System[0] → System[1] → ... → Footer
+```
+
+No top-level element references a position below it. The layout engine computes the stack once, then exposes the results.
+
+**Within systems:** Elements like chords, dynamics, and lyrics query computed layout data (note positions, staff bounds). This is intentional - they respond to content rather than deriving from a linear stack.
+
+### API Design
+
+```typescript
+getY: {
+  content: { top: number; bottom: number };                      // Content region
+  system: (index: number) => { top: number; bottom: number } | null;  // System bounds
+  staff: (index: number) => { top: number; bottom: number } | null;   // Staff bounds
+  notes: (quant?: number) => { top: number; bottom: number };    // Note extent
+  pitch: (pitch: string, staffIndex: number) => number | null;   // Pitch position
+}
+```
+
+### Key Design Choices
+
+| Aspect | Decision |
+|--------|----------|
+| **Model** | Forward-flow stacking for top-level elements |
+| **API shape** | Object with 5 functions returning `{top, bottom}` or `null` |
+| **Invalid inputs** | Return `null` for out-of-bounds indices |
+| **Missing data** | Provide helpful fallbacks (e.g., staff bounds when no notes) |
+| **Collision** | `notes(quant)` returns per-position extent; falls back to system-wide |
+| **Pitch helper** | `pitch('C4', 0)` centralizes clef-aware Y calculation |
+| **Memoization** | Cache bounds objects to avoid recreating on each call |
+
+### Scope
+
+**In scope (Layout Engine):**
+- Absolute Y positions for systems, staves, notes, pitches
+- Memoized bounds computation
+- Fallbacks for empty data
+
+**Out of scope (Consumer responsibility):**
+- Collision clamping (e.g., ChordTrack's min-Y limit)
+- Element-specific margins
+- Animation/transitions
+
+## Consequences
+
+### Positive
+
+- **Single source of truth**: All Y positions come from `layout.getY`
+- **Simple DX**: Four questions map to four functions
+- **Forward-only**: No backwards references; changing header/title spacing propagates naturally
+- **Future-proof**: Lyrics, dynamics, pedal, multi-system use same API
+- **Reduced code**: ~35 lines removed from ScoreCanvas + ChordTrack
+- **Type-safe**: `null` returns for invalid inputs catch errors at compile time
+
+### Negative
+
+- **Migration effort**: ChordTrack props change; ScoreCanvas logic moves to layout engine
+- **Layout engine grows**: ~40 lines added for Y computation (shared across all consumers)
+- **Null checks**: Consumers must handle `null` for staff/system/pitch calls
+
+## Usage Examples
+
+```typescript
+// Chord track (above notes)
+const chordY = layout.getY.notes().top - MARGIN;
+
+// Per-chord collision
+const chordYAtQuant = layout.getY.notes(quant).top - MARGIN;
+
+// Lyrics (below staff)
+const staff = layout.getY.staff(0);
+const lyricsY = staff ? staff.bottom + MARGIN : null;
+
+// Dynamics (below notes)
+const dynamicsY = layout.getY.notes(quant).bottom + MARGIN;
+
+// Pedal (below last staff)
+const lastStaff = layout.getY.staff(lastIndex);
+const pedalY = lastStaff ? lastStaff.bottom + MARGIN : null;
+
+// Title (above content)
+const titleY = layout.getY.content.top - TITLE_HEIGHT - MARGIN;
+
+// Preview note
+const noteY = layout.getY.pitch('C4', staffIndex);
+
+// Multi-system positioning
+const sys = layout.getY.system(1);
+if (sys) positionInSystem(sys.top);
+```
+
+## Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Empty score (no staves) | `notes()` returns default bounds; `staff(0)` returns `null` |
+| No notes at quant | `notes(quant)` falls back to system-wide extent |
+| Invalid staff index | `staff(n)` returns `null` |
+| Invalid system index | `system(n)` returns `null` (currently only `system(0)` is valid) |
+| Invalid pitch/staff combo | `pitch(p, n)` returns `null` |
+| Ledger line notes | Included in `notes()` extent (affects collision) |
+
+**Future features** (grace notes, multi-system, dynamics, pedaling) will use these same accessors when implemented.
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Separate functions (`staffTop`, `staffBottom`, etc.) | More verbose; doesn't group related values |
+| Properties instead of functions | Can't defer computation; index required |
+| Pass collision config as props | Current pattern; causes duplication and fragility |
+| Element-specific helpers (`chordTrackY`, `lyricsY`) | Doesn't scale; hardcodes element types into API |
+| Always return bounds (never null) | Silent failures harder to debug than explicit nulls |
+
+## Related
+
+- [Coordinate Service v2 Spec](../migration/coordinate-service-v2-spec.md) - `getX` implementation
+- [Y Positioning Spec](../migration/y-positioning-spec.md) - Full implementation details
+- Issue #204 - Original coordinate service work

--- a/docs/adr/016-measure-relative-x.md
+++ b/docs/adr/016-measure-relative-x.md
@@ -1,0 +1,129 @@
+# ADR-016: Measure-Relative X Positioning
+
+> **Principle**: Single Source of Truth, Preparation for System Breaks
+> **Status**: Accepted
+> **Date**: 2026-02-14
+> **Spec**: [measure-relative-x-spec.md](../migration/measure-relative-x-spec.md)
+
+## Context
+
+The original `getX(quant)` API returned absolute X coordinates. While this works for single-system scores, it breaks when implementing system breaks (multi-line rendering) where the same measure can appear at different X positions on different lines.
+
+**Original API:**
+```typescript
+layout.getX(globalQuant)  // Returns absolute X (e.g., 450)
+```
+
+**Problem:** With system breaks, measure 5 might start at X=100 on line 1 but X=50 on line 2. A global quant-to-absolute-X mapping cannot represent this.
+
+## Decision
+
+Implement a **measure-relative coordinate system** where:
+
+1. `getX({ measure, quant })` returns position **within** the measure
+2. `getX.measureOrigin({ measure })` returns the measure's **absolute origin**
+3. `NoteLayout.localX` and `EventLayout.localX` are measure-relative
+
+### New API
+
+```typescript
+getX: {
+  /** X position within a measure (measure-relative) */
+  (params: { measure: number; quant: number }): number | null;
+
+  /** Measure's origin X (for SVG transforms) */
+  measureOrigin: (params: { measure: number }) => number | null;
+};
+```
+
+### Key Design Choices
+
+| Aspect | Decision |
+|--------|----------|
+| **Return type** | `number | null` for graceful handling of invalid indices |
+| **Coordinate system** | Measure-relative for positions, absolute for origins |
+| **Layout types** | `NoteLayout.localX` and `EventLayout.localX` are measure-relative |
+| **Hit detection** | Convert to absolute when needed (`origin + localX`) |
+| **Rendering pattern** | Use SVG `<g transform>` with measureOrigin |
+
+### Rendering Pattern
+
+```tsx
+<g transform={`translate(${layout.getX.measureOrigin({ measure }) ?? 0}, 0)`}>
+  <Element x={layout.getX({ measure, quant }) ?? 0} />
+</g>
+```
+
+Or when absolute X is needed:
+```typescript
+const absoluteX = (layout.getX.measureOrigin({ measure }) ?? 0) +
+                  (layout.getX({ measure, quant }) ?? 0);
+```
+
+## Consequences
+
+### Positive
+
+- **System breaks ready**: Same measure can appear at different X positions
+- **Measure insertion robust**: Moving measures doesn't require recalculating global quants
+- **Clear semantics**: Positions are relative to their container (measure)
+- **Type-safe**: `null` returns catch errors at compile time
+- **Single source of truth**: All X positions come from `layout.getX`
+
+### Negative
+
+- **Migration effort**: All getX consumers updated (ChordTrack, Cursor, etc.)
+- **Extra computation**: Absolute X requires `measureOrigin + localX`
+- **API complexity**: Two-step lookup vs single-step
+
+### Neutral
+
+- **ChordSymbol data model**: Now uses `{ measure, quant }` instead of global quant (aligns with API)
+
+## Migration Summary
+
+| Stage | Component | Changes |
+|-------|-----------|---------|
+| 0 | ChordSymbol | `{ measure, quant }` instead of global quant |
+| 1 | ScoreLayout | New `getX` signature with `measureOrigin` |
+| 2 | ChordTrack | Use `getAbsoluteX()` helper |
+| 3 | useCursorLayout | Return `{ measure, x }` instead of absolute X |
+| 4 | ScoreCanvas | Calculate absolute X from measure + localX |
+| 5 | useDragToSelect | Already compatible (has measureIndex) |
+| 6 | Layout types | Rename `x` to `localX` |
+
+All 1209 tests pass after migration.
+
+## Usage Examples
+
+```typescript
+// Get X position for chord at beat 3 of measure 2
+const localX = layout.getX({ measure: 2, quant: 48 });  // e.g., 65
+const origin = layout.getX.measureOrigin({ measure: 2 }); // e.g., 350
+const absoluteX = (origin ?? 0) + (localX ?? 0);  // 415
+
+// Cursor positioning
+const { measure, x: localX } = useCursorLayout(layout, position);
+const cursorX = (layout.getX.measureOrigin({ measure }) ?? 0) + (localX ?? 0);
+
+// NoteLayout is measure-relative
+Object.values(layout.notes).forEach(note => {
+  const absoluteX = (layout.getX.measureOrigin({ measure: note.measureIndex }) ?? 0)
+                  + note.localX;
+});
+```
+
+## Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|--------------|
+| Keep absolute X | Doesn't support system breaks |
+| System-relative X | Still requires offset when system position changes |
+| Per-system layout objects | More complex API, harder to query across systems |
+| Store both absolute and relative | Data duplication, maintenance burden |
+
+## Related
+
+- [Measure-Relative X Spec](../migration/measure-relative-x-spec.md) - Full implementation details
+- [ADR-015: Forward-Flow Y Positioning](./015-forward-flow-y-positioning.md) - Y coordinate design
+- Issue #204 - Coordinate service work

--- a/docs/migration/coordinate-service-spec.md
+++ b/docs/migration/coordinate-service-spec.md
@@ -1,0 +1,202 @@
+# Coordinate Utilities - Technical Spec
+
+**Issue:** [#204](https://github.com/joekotvas/riffscore/issues/204)
+**Date:** 2026-02-13
+
+---
+
+## Problem
+
+X position logic is fragmented:
+- `ScoreCanvas.tsx` has `quantToX` callback with two-stage lookup
+- `ChordTrack.tsx` has `xToNearestQuant` and CTM handling
+- Other components use different approaches
+
+## Solution
+
+Extract 3 utility functions into a shared file. All score elements use the same positioning logic.
+
+---
+
+## Implementation
+
+### New File: `src/engines/layout/coordinateUtils.ts`
+
+```typescript
+import type { Point } from '@/types';
+
+/** Measure position data for interpolation fallback */
+export interface MeasurePosition {
+  x: number;
+  width: number;
+}
+
+/**
+ * Convert quant to X coordinate.
+ * Two-stage lookup: exact match from map, then interpolation fallback.
+ */
+export function quantToX(
+  quant: number,
+  quantToXMap: Map<number, number>,
+  measurePositions: MeasurePosition[],
+  quantsPerMeasure: number
+): number | null {
+  // Stage 1: Exact match (O(1) lookup)
+  const exact = quantToXMap.get(quant);
+  if (exact !== undefined) return exact;
+
+  // Stage 2: Interpolation fallback
+  if (measurePositions.length === 0) return null;
+
+  const measureIndex = Math.floor(quant / quantsPerMeasure);
+  const measure = measurePositions[measureIndex];
+  if (!measure) return null;
+
+  const localQuant = quant % quantsPerMeasure;
+  const proportion = localQuant / quantsPerMeasure;
+  return measure.x + proportion * measure.width;
+}
+
+/**
+ * Find nearest quant position to an X coordinate.
+ */
+export function xToNearestQuant(
+  x: number,
+  validQuants: Set<number>,
+  quantToXFn: (quant: number) => number | null,
+  snapDistance = 24
+): number | null {
+  let nearest: number | null = null;
+  let nearestDist = Infinity;
+
+  for (const quant of validQuants) {
+    const qx = quantToXFn(quant);
+    if (qx === null) continue;
+
+    const dist = Math.abs(x - qx);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearest = quant;
+    }
+  }
+
+  return nearestDist <= snapDistance ? nearest : null;
+}
+
+/**
+ * Transform client (screen) coordinates to SVG local coordinates.
+ * Uses CTM for accurate handling of nested transforms.
+ */
+export function clientToSvg(
+  clientX: number,
+  clientY: number,
+  element: SVGElement
+): Point {
+  const svg = element.ownerSVGElement ?? (element as SVGSVGElement);
+  const parent = element.parentElement as SVGGraphicsElement | null;
+  const ctm = parent?.getScreenCTM() ?? svg?.getScreenCTM();
+
+  if (!svg || !ctm) {
+    // Fallback for detached elements
+    const rect = element.getBoundingClientRect();
+    return { x: clientX - rect.left, y: clientY - rect.top };
+  }
+
+  const pt = svg.createSVGPoint();
+  pt.x = clientX;
+  pt.y = clientY;
+  const transformed = pt.matrixTransform(ctm.inverse());
+  return { x: transformed.x, y: transformed.y };
+}
+```
+
+---
+
+## Migration
+
+### ScoreCanvas.tsx
+
+```diff
++ import { quantToX } from '@/engines/layout/coordinateUtils';
+
+  // In useScoreLayout or ScoreCanvas:
+  const quantToXMap = useMemo(() => buildQuantToXMap(layout, score), [layout, score]);
+  const measurePositions = useMemo(() => buildMeasurePositions(layout), [layout]);
+
+- const quantToXCallback = useCallback((quant: number) => {
+-   const mappedX = quantToXMap.get(quant);
+-   if (mappedX !== undefined) return mappedX;
+-   // ... 15 lines of interpolation logic
+- }, [quantToXMap, measurePositions, quantsPerMeasure]);
+
++ const quantToXCallback = useCallback(
++   (quant: number) => quantToX(quant, quantToXMap, measurePositions, quantsPerMeasure),
++   [quantToXMap, measurePositions, quantsPerMeasure]
++ );
+```
+
+### ChordTrack.tsx
+
+```diff
++ import { clientToSvg, xToNearestQuant } from '@/engines/layout/coordinateUtils';
+
+- function xToNearestQuant(...) { ... }  // Delete ~20 lines
+
+  const handleTrackClick = (e: React.MouseEvent) => {
+-   const svg = e.currentTarget.ownerSVGElement;
+-   const parentGroup = e.currentTarget.parentElement as SVGGraphicsElement | null;
+-   const ctm = parentGroup?.getScreenCTM() ?? svg.getScreenCTM();
+-   const pt = svg.createSVGPoint();
+-   pt.x = e.clientX;
+-   pt.y = e.clientY;
+-   const svgP = pt.matrixTransform(ctm?.inverse());
++   const { x } = clientToSvg(e.clientX, e.clientY, e.currentTarget);
+
+-   const quant = xToNearestQuant(svgP.x, validQuants, quantToX);
++   const quant = xToNearestQuant(x, validQuants, quantToX);
+    // ...
+  };
+```
+
+---
+
+## Result
+
+All X positioning flows through one place:
+
+```
+Layout Engine (computes positions)
+       ↓
+  quantToXMap (built in useScoreLayout)
+       ↓
+  quantToX() ← single function, shared by all
+       ↓
+  Notes, Chords, Cursor, Hit Detection
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/engines/layout/coordinateUtils.ts` | **New** (~70 lines) |
+| `src/engines/layout/index.ts` | Add export |
+| `src/components/Canvas/ScoreCanvas.tsx` | Use `quantToX`, delete duplicate logic |
+| `src/components/Canvas/ChordTrack/ChordTrack.tsx` | Use all 3 utils, delete duplicates |
+
+---
+
+## Testing
+
+**Unit tests:**
+- `quantToX` returns exact match when quant exists in map
+- `quantToX` interpolates correctly for quants between notes
+- `quantToX` returns null for out-of-bounds quants
+- `xToNearestQuant` snaps within distance, returns null outside
+- `clientToSvg` handles nested transforms
+
+**Manual:**
+1. Click in ChordTrack → chord at correct position
+2. Hover over measures → pitch indicator tracks correctly
+3. Playback cursor → follows notes accurately

--- a/docs/migration/coordinate-service-v2-spec.md
+++ b/docs/migration/coordinate-service-v2-spec.md
@@ -1,0 +1,162 @@
+# Coordinate Service v2 - Simplified Architecture
+
+**Issue:** Follow-up to #204
+**Date:** 2026-02-13
+
+---
+
+## Problem
+
+Current positioning architecture is fragmented:
+- `measure.ts` computes `eventPositions[eventId]` (relative)
+- `scoreLayout.ts` converts to `layout.notes[key].x` (absolute)
+- `ScoreCanvas.tsx` builds `quantToXMap` from `layout.notes` (~25 lines)
+- Different elements access positions through different paths
+
+Adding a new positioned element (lyrics, dynamics) requires understanding this whole chain.
+
+---
+
+## Goal
+
+Adding a new positioned element should be one line:
+
+```typescript
+const x = layout.getX(quant);
+```
+
+---
+
+## Solution
+
+Build `getX` function directly in the layout engine. Include it in `ScoreLayout`.
+
+### Updated `ScoreLayout` Interface
+
+```typescript
+// src/engines/layout/types.ts
+
+export interface ScoreLayout {
+  staves: StaffLayout[];
+  notes: Record<string, NoteLayout>;
+  events: Record<string, EventLayout>;
+
+  // NEW: Single function for ALL positioned elements
+  getX: (quant: number) => number;
+}
+```
+
+### Build in Layout Engine
+
+```typescript
+// src/engines/layout/scoreLayout.ts
+
+export const calculateScoreLayout = (score: Score): ScoreLayout => {
+  // ... existing layout computation ...
+
+  // Build quant→X map from note positions
+  const quantToXMap = buildQuantToXMap(layout.notes, score, quantsPerMeasure);
+
+  // Build measure positions for interpolation fallback
+  const measurePositions = layout.staves[0]?.measures.map(m => ({ x: m.x, width: m.width })) ?? [];
+
+  // Pre-bind the lookup function
+  const getX = (quant: number): number =>
+    quantToX(quant, quantToXMap, measurePositions, quantsPerMeasure) ?? 0;
+
+  return { staves, notes, events, getX };
+};
+```
+
+---
+
+## Migration
+
+### ScoreCanvas.tsx
+
+**Remove ~30 lines:**
+```diff
+- import { quantToX as quantToXUtil } from '@/engines/layout/coordinateUtils';
+
+- const quantToXMap = useMemo(() => {
+-   const map = new Map<number, number>();
+-   Object.values(layout.notes).forEach((noteLayout) => {
+-     const measure = score.staves[noteLayout.staffIndex]?.measures[noteLayout.measureIndex];
+-     if (!measure) return;
+-     let localQuant = 0;
+-     for (const event of measure.events) {
+-       if (event.id === noteLayout.eventId) {
+-         const globalQuant = noteLayout.measureIndex * quantsPerMeasure + localQuant;
+-         if (!map.has(globalQuant)) {
+-           map.set(globalQuant, noteLayout.x);
+-         }
+-         break;
+-       }
+-       localQuant += getNoteDuration(event.duration, event.dotted, event.tuplet);
+-     }
+-   });
+-   return map;
+- }, [layout.notes, score.staves, quantsPerMeasure]);
+
+- const quantToX = useCallback(
+-   (quant: number): number => quantToXUtil(quant, quantToXMap, measurePositions, quantsPerMeasure) ?? 0,
+-   [quantToXMap, measurePositions, quantsPerMeasure]
+- );
+
++ // Just use layout.getX directly
++ const quantToX = layout.getX;
+```
+
+### ChordTrack
+
+No changes - still receives `quantToX` as prop.
+
+### Any Future Element
+
+```typescript
+const x = layout.getX(lyric.quant);
+const x = layout.getX(dynamic.quant);
+const x = layout.getX(annotation.quant);
+```
+
+---
+
+## Implementation Steps
+
+1. Add `getX` to `ScoreLayout` interface in `types.ts`
+2. Build `quantToXMap` in `scoreLayout.ts` during layout calculation
+3. Create `getX` function and include in returned layout
+4. Remove map building from `ScoreCanvas.tsx`
+5. Update tests
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/engines/layout/types.ts` | Add `getX: (quant: number) => number` to `ScoreLayout` |
+| `src/engines/layout/scoreLayout.ts` | Build map + `getX` during layout |
+| `src/components/Canvas/ScoreCanvas.tsx` | Remove ~30 lines, use `layout.getX` |
+
+---
+
+## Result
+
+**Before:**
+- ScoreCanvas builds map (20 lines)
+- ScoreCanvas creates callback (5 lines)
+- Multiple dependencies to track
+
+**After:**
+- `layout.getX(quant)` - one function, computed once, used everywhere
+
+```
+score (state)
+    ↓
+useScoreLayout(score)
+    ↓
+layout.getX(quant) ← single source of truth
+    ↓
+Chords, Cursor, Lyrics, Dynamics...
+```

--- a/docs/migration/measure-relative-x-spec.md
+++ b/docs/migration/measure-relative-x-spec.md
@@ -2,7 +2,7 @@
 
 **Issue:** Preparation for system breaks
 **Date:** 2025-02-13
-**Status:** Planned
+**Status:** In Progress (Stages 0-2 Complete)
 
 ---
 
@@ -58,7 +58,9 @@ interface ScoreLayout {
 
 ## Migration Stages
 
-### Stage 0: ChordSymbol Data Model
+### Stage 0: ChordSymbol Data Model ✅ COMPLETE
+
+**Commits:** 7101c84, 0d4b356, c9f50ba, 93cad52, 23b44eb
 
 **Files:**
 - `src/types.ts` — Interface change
@@ -109,7 +111,9 @@ export interface ChordSymbol {
 
 ---
 
-### Stage 1: ScoreLayout API
+### Stage 1: ScoreLayout API ✅ COMPLETE
+
+**Commit:** a586d3a
 
 **Files:**
 - `src/engines/layout/types.ts`
@@ -121,30 +125,34 @@ export interface ChordSymbol {
 3. Implement `getX({ measure, quant })` and `getX.measureOrigin({ measure })`
 4. Remove old `getX(quant)` function
 
-**Test:** `npm test -- scoreLayout` (expect consumer failures)
+**Test:** `npm test -- scoreLayout` ✅ All 33 tests pass
 
 ---
 
-### Stage 2: ChordTrack
+### Stage 2: ChordTrack ✅ COMPLETE
+
+**Commit:** a586d3a (combined with Stage 1)
 
 **Files:**
 - `src/components/Canvas/ChordTrack/ChordTrack.tsx`
 
 **Changes:**
-1. Update chord positioning to use new API
-2. Chords already have `measure` and `quant` (local)
+1. Added `getAbsoluteX(position, layout)` helper combining measureOrigin + localX
+2. Updated `xToNearestPosition` to use new API
+3. Removed `positionToGlobalQuant` bridge function
+4. Cleaned up dependency arrays (removed unused measurePositions, quantsPerMeasure)
 
 **Before:**
 ```typescript
-x={layout.getX(chord.quant)}
+x={layout.getX(positionToGlobalQuant(position, quantsPerMeasure))}
 ```
 
 **After:**
 ```typescript
-x={layout.getX({ measure: chord.measure, quant: chord.quant }) ?? 0}
+x={getAbsoluteX(position, layout)}
 ```
 
-**Test:** `npm test -- ChordTrack`
+**Test:** `npm test -- ChordTrack` ✅ All 101 tests pass
 
 ---
 
@@ -275,10 +283,16 @@ Each stage is independently testable. If issues arise:
 
 ## Success Criteria
 
-- [ ] Stage 0: ChordSymbol uses `{ measure, quant }` instead of global quant
-- [ ] Stage 0: Old scores auto-migrate to new format
-- [ ] All 1205+ tests passing after each stage
+- [x] Stage 0: ChordSymbol uses `{ measure, quant }` instead of global quant
+- [x] Stage 0: Old scores auto-migrate to new format
+- [x] Stage 1: ScoreLayout API updated with measure-relative getX
+- [x] Stage 2: ChordTrack uses new getX API
+- [x] All 1209 tests passing after each stage
+- [ ] Stage 3: useCursorLayout returns measure context
+- [ ] Stage 4: ScoreCanvas cursor uses measure-relative positioning
+- [ ] Stage 5: useDragToSelect updated for measure context
+- [ ] Stage 6: Layout types renamed (x → localX)
+- [ ] Stage 7: Documentation updated
 - [ ] Manual verification: chords, cursor, selection work correctly
 - [ ] No absolute X references remain in layout types
 - [ ] No global quant references remain in chord data model
-- [ ] Documentation updated

--- a/docs/migration/measure-relative-x-spec.md
+++ b/docs/migration/measure-relative-x-spec.md
@@ -1,0 +1,275 @@
+# Measure-Relative X Positioning
+
+**Issue:** Preparation for system breaks
+**Date:** 2025-02-13
+**Status:** Planned
+
+---
+
+## Problem
+
+Current `getX` returns absolute X coordinates, which breaks when measures can appear on different systems at different X offsets.
+
+```typescript
+// Current (absolute)
+layout.getX(globalQuant)  // → 450 (absolute X on canvas)
+```
+
+For system breaks, we need measure-relative positioning where each measure is independently positionable.
+
+---
+
+## Solution
+
+Replace absolute X with measure-relative coordinates.
+
+```typescript
+// New API
+layout.getX({ measure: 0, quant: 24 })     // → 45 (relative to measure origin)
+layout.getX.measureOrigin({ measure: 0 })  // → 120 (measure's absolute X)
+```
+
+**Rendering pattern:**
+```typescript
+<g transform={`translate(${layout.getX.measureOrigin({ measure }) ?? 0}, 0)`}>
+  <Element x={layout.getX({ measure, quant }) ?? 0} />
+</g>
+```
+
+---
+
+## API
+
+```typescript
+interface ScoreLayout {
+  getX: {
+    /** X position within a measure (measure-relative) */
+    (params: { measure: number; quant: number }): number | null;
+
+    /** Measure's origin X (for SVG transforms) */
+    measureOrigin: (params: { measure: number }): number | null;
+  };
+
+  // getY unchanged
+}
+```
+
+---
+
+## Migration Stages
+
+### Stage 0: ChordSymbol Data Model
+
+**Files:**
+- `src/types.ts` — Interface change
+- `src/commands/chord/AddChordCommand.ts` — Accept `{ measure, quant }` instead of global quant
+- `src/commands/chord/UpdateChordCommand.ts` — Update position handling if needed
+- `src/commands/chord/RemoveChordCommand.ts` — No change (uses ID)
+- `src/hooks/chord/useChordTrack.ts` — `creatingAtQuant` → `creatingAt: { measure, quant }`
+- `src/services/chord/ChordQuants.ts` — Return `Set<{ measure: number; quant: number }>` or change approach
+- `src/utils/chord/queries.ts` — `findChordAtQuant` accepts `{ measure, quant }`
+- `src/components/Canvas/ChordTrack/ChordTrack.tsx` — Use new data shape
+- `src/exporters/abcExporter.ts` — Update chord export
+- `src/exporters/musicXmlExporter.ts` — Update chord export
+- Tests: `ChordCommands.test.ts`, `useChordTrack.test.ts`, `ChordTrack.test.tsx`
+
+**Changes:**
+1. Update `ChordSymbol` interface from global quant to measure-local:
+```typescript
+// Before
+export interface ChordSymbol {
+  id: string;
+  quant: number;  // Global quant (measureIndex * quantsPerMeasure + localQuant)
+  symbol: string;
+}
+
+// After
+export interface ChordSymbol {
+  id: string;
+  measure: number;  // Measure index
+  quant: number;    // Local quant within measure
+  symbol: string;
+}
+```
+
+2. Update `AddChordCommand` constructor: `new AddChordCommand({ measure, quant }, symbol)`
+3. Update sorting: `sort((a, b) => a.measure - b.measure || a.quant - b.quant)`
+4. Update `getValidChordQuants` → return `Array<{ measure, quant }>` or `Map<measure, Set<quant>>`
+5. Update `findChordAtQuant` → `findChordAt({ measure, quant })`
+6. Migration: scores with old format get auto-migrated in `migrateScore()`
+
+**Rationale:** Clean data model before API change. Global quant requires recalculation when measures are inserted/deleted. Measure-local is robust to measure operations.
+
+**Test:** `npm test -- chord` (all chord tests should pass)
+
+---
+
+### Stage 1: ScoreLayout API
+
+**Files:**
+- `src/engines/layout/types.ts`
+- `src/engines/layout/scoreLayout.ts`
+
+**Changes:**
+1. Update `ScoreLayout` interface with new `getX` signature
+2. Build per-measure quant→X maps
+3. Implement `getX({ measure, quant })` and `getX.measureOrigin({ measure })`
+4. Remove old `getX(quant)` function
+
+**Test:** `npm test -- scoreLayout` (expect consumer failures)
+
+---
+
+### Stage 2: ChordTrack
+
+**Files:**
+- `src/components/Canvas/ChordTrack/ChordTrack.tsx`
+
+**Changes:**
+1. Update chord positioning to use new API
+2. Chords already have `measure` and `quant` (local)
+
+**Before:**
+```typescript
+x={layout.getX(chord.quant)}
+```
+
+**After:**
+```typescript
+x={layout.getX({ measure: chord.measure, quant: chord.quant }) ?? 0}
+```
+
+**Test:** `npm test -- ChordTrack`
+
+---
+
+### Stage 3: useCursorLayout
+
+**Files:**
+- `src/hooks/layout/useCursorLayout.ts`
+
+**Changes:**
+1. Use `layout.getX({ measure, quant })` instead of building own map
+2. Return `{ measure, x }` instead of absolute X
+
+**Before:**
+```typescript
+return { x: absoluteX, width, ... };
+```
+
+**After:**
+```typescript
+return { measure, x: localX, width, ... };
+```
+
+**Test:** `npm test -- useCursorLayout`
+
+---
+
+### Stage 4: ScoreCanvas Cursor
+
+**Files:**
+- `src/components/Canvas/ScoreCanvas.tsx`
+
+**Changes:**
+1. Apply measure transform to cursor positioning
+
+**Before:**
+```typescript
+transform: `translateX(${unifiedCursorX}px)`
+```
+
+**After:**
+```typescript
+transform: `translateX(${layout.getX.measureOrigin({ measure: cursor.measure }) + cursor.x}px)`
+```
+
+**Test:** `npm test -- ScoreCanvas`
+
+---
+
+### Stage 5: useDragToSelect
+
+**Files:**
+- `src/hooks/interaction/useDragToSelect.ts`
+- `src/components/Canvas/ScoreCanvas.tsx` (notePositions)
+
+**Changes:**
+1. Update `notePositions` to include measure context
+2. Selection rect intersection works per-measure
+
+**Test:** `npm test -- useDragToSelect`
+
+---
+
+### Stage 6: Layout Types Cleanup
+
+**Files:**
+- `src/engines/layout/types.ts`
+- `src/engines/layout/scoreLayout.ts`
+
+**Changes:**
+1. Rename `NoteLayout.x` → `NoteLayout.localX`
+2. Rename `EventLayout.x` → `EventLayout.localX`
+3. Remove any remaining absolute X references
+
+**Test:** `npm test` (full suite)
+
+---
+
+### Stage 7: Documentation
+
+**Files:**
+- `docs/LAYOUT_ENGINE.md` — Update getX documentation
+- `docs/adr/016-measure-relative-x.md` — Create ADR
+
+---
+
+## Affected Components
+
+| Component | Change | Complexity |
+|-----------|--------|------------|
+| `types.ts` (ChordSymbol) | Add `measure` field, remove global quant | Low |
+| `AddChordCommand.ts` | Accept `{ measure, quant }` params | Medium |
+| `useChordTrack.ts` | `creatingAt` instead of `creatingAtQuant` | Medium |
+| `ChordQuants.ts` | Return structured quant positions | Medium |
+| `queries.ts` | Update `findChordAtQuant` signature | Low |
+| `scoreLayout.ts` | New getX implementation | Medium |
+| `ChordTrack.tsx` | Use new API + data model | Medium |
+| `useCursorLayout.ts` | Return measure context | Medium |
+| `ScoreCanvas.tsx` | Cursor transform | Low |
+| `useDragToSelect.ts` | Per-measure hit detection | Medium |
+| `NoteLayout/EventLayout` | Rename x → localX | Low |
+| `abcExporter.ts` | Update chord export | Low |
+| `musicXmlExporter.ts` | Update chord export | Low |
+
+---
+
+## Not In Scope
+
+- System breaks implementation (future)
+- Multi-system rendering (future)
+- Tie splitting at system breaks (future)
+
+This migration prepares the coordinate system. System breaks will be a separate effort.
+
+---
+
+## Rollback
+
+Each stage is independently testable. If issues arise:
+1. Revert the stage's changes
+2. Tests should pass again
+3. Investigate before retrying
+
+---
+
+## Success Criteria
+
+- [ ] Stage 0: ChordSymbol uses `{ measure, quant }` instead of global quant
+- [ ] Stage 0: Old scores auto-migrate to new format
+- [ ] All 1205+ tests passing after each stage
+- [ ] Manual verification: chords, cursor, selection work correctly
+- [ ] No absolute X references remain in layout types
+- [ ] No global quant references remain in chord data model
+- [ ] Documentation updated

--- a/docs/migration/measure-relative-x-spec.md
+++ b/docs/migration/measure-relative-x-spec.md
@@ -66,8 +66,13 @@ interface ScoreLayout {
 - `src/commands/chord/UpdateChordCommand.ts` — Update position handling if needed
 - `src/commands/chord/RemoveChordCommand.ts` — No change (uses ID)
 - `src/hooks/chord/useChordTrack.ts` — `creatingAtQuant` → `creatingAt: { measure, quant }`
-- `src/services/chord/ChordQuants.ts` — Return `Set<{ measure: number; quant: number }>` or change approach
-- `src/utils/chord/queries.ts` — `findChordAtQuant` accepts `{ measure, quant }`
+- `src/services/chord/ChordQuants.ts` — Return `Map<measure, Set<quant>>` for efficient lookup
+- `src/utils/chord/queries.ts` — `findChordAtQuant` → `findChordAt({ measure, quant })`
+- `src/utils/navigation/vertical.ts` — Update chord lookup in navigation
+- `src/engines/toneEngine.ts` — Update playback timing (use `chord.measure` directly)
+- `src/hooks/api/chords.ts` — Update API methods (logging, selection)
+- `src/components/Layout/ScoreEditor.tsx` — Update chord selection
+- `src/components/Canvas/ScoreCanvas.tsx` — Update chord navigation
 - `src/components/Canvas/ChordTrack/ChordTrack.tsx` — Use new data shape
 - `src/exporters/abcExporter.ts` — Update chord export
 - `src/exporters/musicXmlExporter.ts` — Update chord export
@@ -229,15 +234,19 @@ transform: `translateX(${layout.getX.measureOrigin({ measure: cursor.measure }) 
 
 | Component | Change | Complexity |
 |-----------|--------|------------|
-| `types.ts` (ChordSymbol) | Add `measure` field, remove global quant | Low |
+| `types.ts` (ChordSymbol) | Add `measure` field, local quant | Low |
 | `AddChordCommand.ts` | Accept `{ measure, quant }` params | Medium |
 | `useChordTrack.ts` | `creatingAt` instead of `creatingAtQuant` | Medium |
-| `ChordQuants.ts` | Return structured quant positions | Medium |
-| `queries.ts` | Update `findChordAtQuant` signature | Low |
+| `ChordQuants.ts` | Return `Map<measure, Set<quant>>` | Medium |
+| `queries.ts` | `findChordAt({ measure, quant })` | Low |
+| `vertical.ts` | Update chord lookup in navigation | Low |
+| `toneEngine.ts` | Use `chord.measure` for timing | Medium |
+| `chords.ts` (API) | Update logging and selection | Low |
+| `ScoreEditor.tsx` | Update chord selection | Low |
+| `ScoreCanvas.tsx` | Update chord navigation + cursor | Medium |
+| `ChordTrack.tsx` | Use new data shape | Medium |
 | `scoreLayout.ts` | New getX implementation | Medium |
-| `ChordTrack.tsx` | Use new API + data model | Medium |
 | `useCursorLayout.ts` | Return measure context | Medium |
-| `ScoreCanvas.tsx` | Cursor transform | Low |
 | `useDragToSelect.ts` | Per-measure hit detection | Medium |
 | `NoteLayout/EventLayout` | Rename x → localX | Low |
 | `abcExporter.ts` | Update chord export | Low |

--- a/docs/migration/y-positioning-spec.md
+++ b/docs/migration/y-positioning-spec.md
@@ -1,0 +1,499 @@
+# Y Positioning API - Centralized Vertical Anchors
+
+**Issue:** Follow-up to coordinate-service-v2 (#204)
+**Date:** 2026-02-13
+
+---
+
+## Terminology
+
+| Term | Definition |
+|------|------------|
+| **System** | One line of music on a page. Contains all staves (e.g., treble + bass for grand staff) rendered horizontally together. |
+| **System break** | A line break - where music wraps to the next system. |
+| **Staff** | A single 5-line pentagram within a system. A grand staff system has 2 staves. |
+| **Quant** | Time position unit. 96 quants = 1 whole note, 24 = quarter note. |
+
+---
+
+## Problem
+
+Adding a floating element requires understanding scattered vertical spacing logic:
+
+```typescript
+// Current: scattered across ScoreCanvas.tsx + ChordTrack.tsx (~66 lines)
+// - CHORD_COLLISION constants
+// - noteYByQuant map computation
+// - chordTrackY baseline calculation
+// - getChordYOffset collision logic
+```
+
+**Pain points:**
+1. No single source of truth for vertical positions
+2. Adjusting spacing (e.g., title-to-score gap) breaks cursor/hit detection
+3. New elements must duplicate Y calculation logic
+4. Backwards references between components cause fragility
+
+---
+
+## Goal
+
+**Simple DX:** Four questions, four functions.
+
+| Question | Function |
+|----------|----------|
+| "Where is system N?" | `getY.system(n).top/bottom` |
+| "Where is staff N?" | `getY.staff(n).top/bottom` |
+| "Where are the notes?" | `getY.notes(q?).top/bottom` |
+| "Where is this pitch?" | `getY.pitch(p, staffIndex)` |
+
+Plus one region anchor for the overall content area.
+
+---
+
+## Solution
+
+### Vertical Stack (Forward-Flow)
+
+The forward-flow model applies to top-level elements. Each derives from the previous:
+
+```
+Y=0 (origin)
+  │
+  ├── Header: 0 → header.height
+  │
+  ├── Title: header.bottom + margin → title.bottom
+  │
+  ├── System[0]: title.bottom + margin → system[0].bottom
+  │     │
+  │     ├── ChordTrack (floats above notes)
+  │     │
+  │     ├── Staff[0]: system.top → staff[0].bottom
+  │     │     ├── Dynamics (above)
+  │     │     ├── Pentagram (5 lines)
+  │     │     └── Lyrics (below)
+  │     │
+  │     ├── Staff[1]: staff[0].bottom + spacing → staff[1].bottom
+  │     │
+  │     └── Pedal: lastStaff.bottom + margin
+  │
+  ├── System[1]: system[0].bottom + margin → system[1].bottom  (after system break)
+  │
+  └── Footer: lastSystem.bottom + margin → footer.bottom
+```
+
+**Key invariant:** No backwards references in the stack. Each top-level position derives from elements above it.
+
+**Within a system:** Elements like chords, dynamics, and lyrics query computed layout data (note positions, staff bounds) rather than deriving from a linear stack. This is intentional - they need to respond to actual content.
+
+### API
+
+```typescript
+// src/engines/layout/types.ts
+
+export interface YBounds {
+  top: number;
+  bottom: number;
+}
+
+export interface ScoreLayout {
+  staves: StaffLayout[];
+  notes: Record<string, NoteLayout>;
+  events: Record<string, EventLayout>;
+
+  getX: (quant: number) => number;
+
+  getY: {
+    // Content region (forward-flow computed)
+    content: YBounds;
+
+    // System bounds (for multi-system/page view)
+    system: (index: number) => YBounds | null;
+
+    // Staff bounds within a system
+    staff: (index: number) => YBounds | null;
+
+    // Note extent for collision avoidance
+    // - No arg: returns extent across entire system (memoized)
+    // - With quant: returns extent at that position, falls back to system-wide
+    notes: (quant?: number) => YBounds;
+
+    // Pitch Y position (clef-aware)
+    // - Returns null if staffIndex is invalid
+    pitch: (pitch: string, staffIndex: number) => number | null;
+  };
+}
+```
+
+### Return Values & Edge Cases
+
+| Function | Invalid Input | Return |
+|----------|---------------|--------|
+| `system(99)` on 1-system score | Out of bounds | `null` |
+| `staff(99)` on 2-staff score | Out of bounds | `null` |
+| `notes()` on empty score | No notes exist | Staff bounds as fallback |
+| `notes(quant)` with no notes at quant | No notes at position | System-wide extent as fallback |
+| `pitch('C4', 99)` on 2-staff score | Invalid staff | `null` |
+
+**Design rationale:** Return `null` for truly invalid inputs (bad indices). Provide helpful fallbacks when the query is valid but no data exists (empty measures).
+
+### Usage
+
+```typescript
+// Chord track: above notes (collision-aware)
+const chordY = layout.getY.notes().top - MARGIN;
+const chordYAtQuant = layout.getY.notes(quant).top - MARGIN;
+
+// Lyrics: below staff
+const staffBounds = layout.getY.staff(0);
+const lyricsY = staffBounds ? staffBounds.bottom + MARGIN : null;
+
+// Dynamics: below notes at position
+const dynamicsY = layout.getY.notes(quant).bottom + MARGIN;
+
+// Pedal: below last staff
+const lastStaff = layout.getY.staff(lastIndex);
+const pedalY = lastStaff ? lastStaff.bottom + MARGIN : null;
+
+// Title: above content area
+const titleY = layout.getY.content.top - TITLE_HEIGHT - MARGIN;
+
+// Bar line: spans all staves
+const firstStaff = layout.getY.staff(0);
+const lastStaff = layout.getY.staff(lastIndex);
+if (firstStaff && lastStaff) {
+  drawBarLine(firstStaff.top, lastStaff.bottom);
+}
+
+// Preview note at pitch
+const noteY = layout.getY.pitch('C4', staffIndex);
+if (noteY !== null) {
+  drawPreviewNote(noteY);
+}
+
+// Footer: below content
+const footerY = layout.getY.content.bottom + MARGIN;
+
+// Multi-system: position element in system 2
+const sys2 = layout.getY.system(1);
+if (sys2) {
+  positionInSystem(sys2.top);
+}
+```
+
+**Mental model:** Four simple questions. Null-check for indices, fallbacks for missing data.
+
+---
+
+## Scope
+
+### This Implementation
+- Single-system layout (no system breaks yet)
+- `system(0)` returns bounds; `system(n>0)` returns `null`
+- Note extent from standard notes (no grace notes yet)
+- ChordTrack migration as proof of concept
+
+### Future-Proofed For
+- **Multi-system / page view**: `system(n)` accessor ready
+- **Grace notes**: Will be included in `notes()` extent when implemented
+- **Lyrics, dynamics, pedaling**: Will use `staff().bottom`, `notes().bottom` anchors
+- **System breaks**: Each system gets independent Y stack
+
+### In Scope (Layout Engine)
+- Absolute Y positions for systems, staves, notes, pitches
+- Memoized bounds computation
+- Fallbacks for empty data
+
+### Out of Scope (Consumer Responsibility)
+- **Collision clamping** (e.g., ChordTrack's `PER_CHORD_MIN_Y` limit)
+- **Element-specific margins** (each consumer defines its own)
+- **Animation/transitions**
+
+The API provides positions; consumers apply constraints.
+
+---
+
+## Implementation
+
+### Build in Layout Engine
+
+```typescript
+// src/engines/layout/scoreLayout.ts
+
+export const calculateScoreLayout = (score: Score): ScoreLayout => {
+  // ... existing layout computation ...
+
+  // --- Forward-flow Y computation ---
+
+  // Content region starts after header/title space
+  const contentTop = CONFIG.contentTopMargin;
+  const contentBottom = layout.staves[layout.staves.length - 1]?.y + CONFIG.staffHeight
+    ?? contentTop + CONFIG.defaultSystemHeight;
+
+  // Memoized system bounds (currently single-system)
+  const systemBoundsCache = new Map<number, YBounds | null>();
+  const system = (index: number): YBounds | null => {
+    if (systemBoundsCache.has(index)) return systemBoundsCache.get(index)!;
+
+    // Currently single-system; returns null for index > 0
+    if (index !== 0 || layout.staves.length === 0) {
+      systemBoundsCache.set(index, null);
+      return null;
+    }
+
+    const bounds = { top: contentTop, bottom: contentBottom };
+    systemBoundsCache.set(index, bounds);
+    return bounds;
+  };
+
+  // Memoized staff bounds
+  const staffBoundsCache = new Map<number, YBounds | null>();
+  const staff = (index: number): YBounds | null => {
+    if (staffBoundsCache.has(index)) return staffBoundsCache.get(index)!;
+
+    const staffLayout = layout.staves[index];
+    if (!staffLayout) {
+      staffBoundsCache.set(index, null);
+      return null;
+    }
+
+    const bounds = { top: staffLayout.y, bottom: staffLayout.y + CONFIG.staffHeight };
+    staffBoundsCache.set(index, bounds);
+    return bounds;
+  };
+
+  // Note extent (system-wide) - computed once, memoized
+  const allNoteYs = Object.values(layout.notes).map(n => n.y);
+  const defaultBounds = staff(0) ?? { top: CONFIG.baseY, bottom: CONFIG.baseY + CONFIG.staffHeight };
+  const systemNoteBounds: YBounds = allNoteYs.length > 0
+    ? { top: Math.min(...allNoteYs), bottom: Math.max(...allNoteYs) }
+    : defaultBounds;
+
+  // Per-quant maps (built once)
+  const noteTopByQuant = new Map<number, number>();
+  const noteBottomByQuant = new Map<number, number>();
+
+  Object.values(layout.notes).forEach((noteLayout) => {
+    const globalQuant = computeGlobalQuant(noteLayout, score, quantsPerMeasure);
+
+    const currentTop = noteTopByQuant.get(globalQuant) ?? Infinity;
+    if (noteLayout.y < currentTop) noteTopByQuant.set(globalQuant, noteLayout.y);
+
+    const currentBottom = noteBottomByQuant.get(globalQuant) ?? -Infinity;
+    if (noteLayout.y > currentBottom) noteBottomByQuant.set(globalQuant, noteLayout.y);
+  });
+
+  const notes = (quant?: number): YBounds => {
+    if (quant === undefined) {
+      return systemNoteBounds;
+    }
+    return {
+      top: noteTopByQuant.get(quant) ?? systemNoteBounds.top,
+      bottom: noteBottomByQuant.get(quant) ?? systemNoteBounds.bottom,
+    };
+  };
+
+  // Pitch positioning (clef-aware)
+  const pitch = (p: string, staffIndex: number): number | null => {
+    const staffLayout = layout.staves[staffIndex];
+    if (!staffLayout) return null;
+
+    const clef = score.staves[staffIndex]?.clef ?? (staffIndex === 0 ? 'treble' : 'bass');
+    return staffLayout.y + getOffsetForPitch(p, clef);
+  };
+
+  const getY = {
+    content: { top: contentTop, bottom: contentBottom },
+    system,
+    staff,
+    notes,
+    pitch,
+  };
+
+  return { ...layout, getX, getY };
+};
+```
+
+---
+
+## Migration
+
+### ScoreCanvas.tsx
+
+**Remove ~45 lines:**
+
+```diff
+- const CHORD_COLLISION = useMemo(() => ({ ... }), []);
+- const noteYByQuant = useMemo(() => { ... }, [...]);
+- const chordTrackY = useMemo(() => { ... }, [...]);
+
+  <ChordTrack
+-   trackY={chordTrackY}
+-   noteYByQuant={noteYByQuant}
+-   collisionConfig={CHORD_COLLISION}
++   layout={layout}
+    ...
+  />
+```
+
+### ChordTrack.tsx
+
+**Simplify Y logic, keep collision clamping:**
+
+```diff
++ const CHORD_MARGIN = 20;
++ const MIN_CHORD_Y = 0;  // Consumer-side clamping (was PER_CHORD_MIN_Y)
+
+  export const ChordTrack = memo(function ChordTrack({
+-   trackY,
+-   noteYByQuant,
+-   collisionConfig,
++   layout,
+  }) {
++   const trackY = layout.getY.notes().top - CHORD_MARGIN;
+
+-   const getChordYOffset = useCallback((quant) => {
+-     const noteY = noteYByQuant.get(quant);
+-     if (noteY === undefined) return 0;
+-     // ... 10 more lines
+-   }, [noteYByQuant, collisionConfig, trackY]);
+
++   const getChordYOffset = (quant: number): number => {
++     const noteY = layout.getY.notes(quant).top;
++     if (noteY >= trackY) return 0;
++
++     // Collision: move chord up, but clamp to MIN_CHORD_Y
++     const idealY = noteY - CHORD_MARGIN;
++     const clampedY = Math.max(MIN_CHORD_Y, idealY);
++     return clampedY - trackY;
++   };
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `types.ts` | Add `YBounds`, update `ScoreLayout` with `getY` |
+| `scoreLayout.ts` | Build forward-flow Y + memoized `getY` object |
+| `ScoreCanvas.tsx` | Remove ~45 lines, pass `layout` |
+| `ChordTrack.tsx` | Use `layout.getY`, keep clamping (~20 lines removed) |
+| `scoreLayout.test.ts` | Add `getY` tests |
+
+---
+
+## Testing
+
+```typescript
+describe('layout.getY', () => {
+  describe('system()', () => {
+    it('returns bounds for system 0', () => {
+      const layout = calculateScoreLayout(createTestScore());
+      const sys = layout.getY.system(0);
+      expect(sys).not.toBeNull();
+      expect(sys!.top).toBeLessThan(sys!.bottom);
+    });
+
+    it('returns null for invalid system index', () => {
+      const layout = calculateScoreLayout(createTestScore());
+      expect(layout.getY.system(99)).toBeNull();
+    });
+  });
+
+  describe('staff()', () => {
+    it('returns bounds for valid staff', () => {
+      const layout = calculateScoreLayout(createTestScore());
+      const s0 = layout.getY.staff(0);
+      expect(s0).not.toBeNull();
+      expect(s0!.bottom - s0!.top).toBe(CONFIG.staffHeight);
+    });
+
+    it('returns null for invalid staff index', () => {
+      const layout = calculateScoreLayout(createTestScore());
+      expect(layout.getY.staff(99)).toBeNull();
+    });
+  });
+
+  describe('notes()', () => {
+    it('returns system-wide extent without arg', () => {
+      const layout = calculateScoreLayout(createTestScore());
+      const extent = layout.getY.notes();
+      expect(extent.top).toBeLessThanOrEqual(extent.bottom);
+    });
+
+    it('returns per-quant extent with arg', () => {
+      const layout = calculateScoreLayout(createTestScore());
+      const extent = layout.getY.notes(0);
+      expect(extent.top).toBeDefined();
+      expect(extent.bottom).toBeDefined();
+    });
+
+    it('falls back to system-wide for empty quant', () => {
+      const layout = calculateScoreLayout(createTestScore());
+      const system = layout.getY.notes();
+      const atQuant = layout.getY.notes(9999);
+      expect(atQuant).toEqual(system);
+    });
+  });
+
+  describe('pitch()', () => {
+    it('returns Y for valid pitch and staff', () => {
+      const layout = calculateScoreLayout(createTestScore());
+      const y = layout.getY.pitch('C4', 0);
+      expect(y).not.toBeNull();
+      expect(typeof y).toBe('number');
+    });
+
+    it('returns null for invalid staff', () => {
+      const layout = calculateScoreLayout(createTestScore());
+      expect(layout.getY.pitch('C4', 99)).toBeNull();
+    });
+  });
+});
+```
+
+---
+
+## Result
+
+**Before:** 66 lines of Y logic across ScoreCanvas + ChordTrack
+
+**After:** ~10 lines per component, shared memoized layout computation
+
+**DX:**
+```typescript
+// Adding lyrics?
+const staff = layout.getY.staff(0);
+const y = staff ? staff.bottom + MARGIN : null;
+
+// Adding dynamics?
+const y = layout.getY.notes(quant).bottom + MARGIN;
+
+// Adding chord track?
+const y = layout.getY.notes().top - MARGIN;
+
+// Preview note?
+const y = layout.getY.pitch('C4', 0);
+
+// Multi-system positioning?
+const sys = layout.getY.system(systemIndex);
+```
+
+**Architecture:**
+```
+score (state)
+    │
+useScoreLayout(score)
+    │
+    ├── layout.getX(quant)         ← horizontal
+    └── layout.getY                ← vertical (forward-flow stack)
+            │
+            ├── .content           ← { top, bottom }
+            ├── .system(n)         ← { top, bottom } | null
+            ├── .staff(n)          ← { top, bottom } | null
+            ├── .notes(q?)         ← { top, bottom } (with fallback)
+            └── .pitch(p, n)       ← number | null
+            │
+    Title, Chords, Staff, Lyrics, Dynamics, Pedal, Footer...
+```

--- a/src/__tests__/ScoreAPI.cookbook.test.tsx
+++ b/src/__tests__/ScoreAPI.cookbook.test.tsx
@@ -287,16 +287,21 @@ describe('Cookbook: Chord Symbol Recipes', () => {
         .addNote('F4', 'quarter');
     });
 
-    // Get valid positions (quantsPerBeat varies by environment)
-    const validQuants = score.getValidChordQuants();
-    expect(validQuants.length).toBeGreaterThanOrEqual(4);
+    // Get valid positions (returns Map<measure, Set<quant>>)
+    const validPositions = score.getValidChordPositions();
+    const measureQuants = validPositions.get(0);
+    expect(measureQuants).toBeDefined();
+    expect(measureQuants!.size).toBeGreaterThanOrEqual(4);
+
+    // Convert to sorted array for test assertions
+    const sortedQuants = Array.from(measureQuants!).sort((a, b) => a - b);
 
     // Add chords at beat 1 and beat 2
     act(() => {
-      score.addChord(validQuants[0], 'C');
+      score.addChord({ measure: 0, quant: sortedQuants[0] }, 'C');
     });
     act(() => {
-      score.addChord(validQuants[1], 'F');
+      score.addChord({ measure: 0, quant: sortedQuants[1] }, 'F');
     });
 
     expect(score.ok).toBe(true);
@@ -304,9 +309,9 @@ describe('Cookbook: Chord Symbol Recipes', () => {
     const chords = score.getChords();
     expect(chords.length).toBe(2);
     expect(chords[0].symbol).toBe('C');
-    expect(chords[0].quant).toBe(validQuants[0]);
+    expect(chords[0].quant).toBe(sortedQuants[0]);
     expect(chords[1].symbol).toBe('F');
-    expect(chords[1].quant).toBe(validQuants[1]);
+    expect(chords[1].quant).toBe(sortedQuants[1]);
   });
 
   /**
@@ -329,13 +334,14 @@ describe('Cookbook: Chord Symbol Recipes', () => {
         .addNote('F4', 'quarter');
     });
 
-    const validQuants = score.getValidChordQuants();
+    const validPositions = score.getValidChordPositions();
+    const measureQuants = Array.from(validPositions.get(0) || []).sort((a, b) => a - b);
 
     act(() => {
-      score.addChord(validQuants[0], 'C');
+      score.addChord({ measure: 0, quant: measureQuants[0] }, 'C');
     });
     act(() => {
-      score.addChord(validQuants[1], 'F');
+      score.addChord({ measure: 0, quant: measureQuants[1] }, 'F');
     });
 
     // Get all chords, select the second one

--- a/src/__tests__/commands/chord/ChordCommands.test.ts
+++ b/src/__tests__/commands/chord/ChordCommands.test.ts
@@ -566,7 +566,9 @@ describe('Chord Commands Integration', () => {
 
   it('handles edge case: empty symbol string', () => {
     // Command should throw on empty symbol
-    expect(() => new AddChordCommand({ measure: 0, quant: 0 }, '')).toThrow(/symbol cannot be empty/);
+    expect(() => new AddChordCommand({ measure: 0, quant: 0 }, '')).toThrow(
+      /symbol cannot be empty/
+    );
   });
 
   it('handles complex chord symbols', () => {

--- a/src/__tests__/components/ChordTrack/ChordSymbol.test.tsx
+++ b/src/__tests__/components/ChordTrack/ChordSymbol.test.tsx
@@ -39,6 +39,7 @@ jest.mock('@/services/ChordService', () => ({
 describe('ChordSymbol', () => {
   const defaultChord: ChordSymbolType = {
     id: 'chord-1',
+    measure: 0,
     quant: 0,
     symbol: 'Cmaj7',
   };
@@ -128,6 +129,7 @@ describe('ChordSymbol', () => {
 
       const amChord: ChordSymbolType = {
         id: 'chord-2',
+        measure: 0,
         quant: 24,
         symbol: 'Am7',
       };

--- a/src/__tests__/components/ChordTrack/ChordTrack.test.tsx
+++ b/src/__tests__/components/ChordTrack/ChordTrack.test.tsx
@@ -364,7 +364,11 @@ describe('ChordTrack', () => {
 
       render(
         <svg data-testid="test-svg">
-          <ChordTrack {...defaultProps} validPositions={validPositions} onEmptyClick={onEmptyClick} />
+          <ChordTrack
+            {...defaultProps}
+            validPositions={validPositions}
+            onEmptyClick={onEmptyClick}
+          />
         </svg>
       );
 
@@ -451,7 +455,11 @@ describe('ChordTrack', () => {
     it('shows ChordInput for new chord creation', () => {
       render(
         <svg>
-          <ChordTrack {...defaultProps} editingChordId="new" creatingAt={{ measure: 1, quant: 8 }} />
+          <ChordTrack
+            {...defaultProps}
+            editingChordId="new"
+            creatingAt={{ measure: 1, quant: 8 }}
+          />
         </svg>
       );
 
@@ -463,7 +471,11 @@ describe('ChordTrack', () => {
     it('passes empty string as initialValue for new chord', () => {
       render(
         <svg>
-          <ChordTrack {...defaultProps} editingChordId="new" creatingAt={{ measure: 1, quant: 8 }} />
+          <ChordTrack
+            {...defaultProps}
+            editingChordId="new"
+            creatingAt={{ measure: 1, quant: 8 }}
+          />
         </svg>
       );
 
@@ -581,7 +593,11 @@ describe('ChordTrack', () => {
     it('does not show preview when editing', () => {
       render(
         <svg data-testid="test-svg">
-          <ChordTrack {...defaultProps} editingChordId="new" creatingAt={{ measure: 1, quant: 8 }} />
+          <ChordTrack
+            {...defaultProps}
+            editingChordId="new"
+            creatingAt={{ measure: 1, quant: 8 }}
+          />
         </svg>
       );
 

--- a/src/__tests__/engines/layout/coordinateUtils.test.ts
+++ b/src/__tests__/engines/layout/coordinateUtils.test.ts
@@ -1,0 +1,170 @@
+/**
+ * coordinateUtils.test.ts
+ *
+ * Unit tests for coordinate transformation utilities.
+ *
+ * @see Issue #204
+ */
+import {
+  quantToX,
+  xToNearestQuant,
+  clientToSvg,
+  MeasurePosition,
+} from '@/engines/layout/coordinateUtils';
+
+describe('coordinateUtils', () => {
+  describe('quantToX', () => {
+    const quantsPerMeasure = 96; // 4/4 time
+
+    it('returns exact match from map when quant exists', () => {
+      const map = new Map<number, number>([
+        [0, 100],
+        [24, 150],
+        [48, 200],
+      ]);
+      const measurePositions: MeasurePosition[] = [{ x: 100, width: 200 }];
+
+      expect(quantToX(0, map, measurePositions, quantsPerMeasure)).toBe(100);
+      expect(quantToX(24, map, measurePositions, quantsPerMeasure)).toBe(150);
+      expect(quantToX(48, map, measurePositions, quantsPerMeasure)).toBe(200);
+    });
+
+    it('interpolates correctly for quants between notes', () => {
+      const map = new Map<number, number>(); // Empty map forces interpolation
+      const measurePositions: MeasurePosition[] = [{ x: 100, width: 200 }];
+
+      // Quarter note at beat 2 (quant 24) should be 25% through measure
+      const result = quantToX(24, map, measurePositions, quantsPerMeasure);
+      expect(result).toBeCloseTo(100 + 0.25 * 200); // 150
+    });
+
+    it('interpolates across multiple measures', () => {
+      const map = new Map<number, number>();
+      const measurePositions: MeasurePosition[] = [
+        { x: 100, width: 200 },
+        { x: 300, width: 200 },
+      ];
+
+      // Beat 1 of measure 2 (quant 96) should be at x=300
+      const result = quantToX(96, map, measurePositions, quantsPerMeasure);
+      expect(result).toBe(300);
+
+      // Beat 2 of measure 2 (quant 120) should be 25% through measure 2
+      const result2 = quantToX(120, map, measurePositions, quantsPerMeasure);
+      expect(result2).toBeCloseTo(300 + 0.25 * 200); // 350
+    });
+
+    it('returns null for out-of-bounds quants', () => {
+      const map = new Map<number, number>();
+      const measurePositions: MeasurePosition[] = [{ x: 100, width: 200 }];
+
+      // Quant 192 would be in measure 2, which doesn't exist
+      expect(quantToX(192, map, measurePositions, quantsPerMeasure)).toBeNull();
+    });
+
+    it('returns null when measurePositions is empty', () => {
+      const map = new Map<number, number>();
+      const measurePositions: MeasurePosition[] = [];
+
+      expect(quantToX(0, map, measurePositions, quantsPerMeasure)).toBeNull();
+    });
+
+    it('prefers exact match over interpolation', () => {
+      // If exact match exists, it should be used even if interpolation would give different result
+      const map = new Map<number, number>([[24, 175]]); // Exact position at quant 24
+      const measurePositions: MeasurePosition[] = [{ x: 100, width: 200 }];
+
+      // Interpolation would give 150, but exact match is 175
+      expect(quantToX(24, map, measurePositions, quantsPerMeasure)).toBe(175);
+    });
+  });
+
+  describe('xToNearestQuant', () => {
+    it('snaps to nearest quant within distance', () => {
+      const validQuants = new Set([0, 24, 48, 72]);
+      const quantToXFn = (q: number): number => 100 + q * 2; // Linear mapping
+
+      // X=145 is closest to quant 24 (x=148)
+      expect(xToNearestQuant(145, validQuants, quantToXFn, 24)).toBe(24);
+
+      // X=200 is closest to quant 48 (x=196)
+      expect(xToNearestQuant(200, validQuants, quantToXFn, 24)).toBe(48);
+    });
+
+    it('returns null when outside snap distance', () => {
+      const validQuants = new Set([0, 96]); // Beat 1 and beat 5 only
+      const quantToXFn = (q: number): number => 100 + q * 2;
+
+      // X=150 is 50px from quant 0 (x=100) and 92px from quant 96 (x=292)
+      // With snapDistance=24, neither is close enough
+      expect(xToNearestQuant(150, validQuants, quantToXFn, 24)).toBeNull();
+    });
+
+    it('returns null for empty validQuants', () => {
+      const validQuants = new Set<number>();
+      const quantToXFn = (q: number): number => 100 + q * 2;
+
+      expect(xToNearestQuant(100, validQuants, quantToXFn, 24)).toBeNull();
+    });
+
+    it('uses default snap distance of 24', () => {
+      const validQuants = new Set([0]);
+      const quantToXFn = (q: number): number => 100 + q * 2;
+
+      // X=124 is exactly 24px from quant 0 (x=100), should snap
+      expect(xToNearestQuant(124, validQuants, quantToXFn)).toBe(0);
+
+      // X=125 is 25px away, should not snap with default distance
+      expect(xToNearestQuant(125, validQuants, quantToXFn)).toBeNull();
+    });
+
+    it('handles quantToXFn returning null', () => {
+      const validQuants = new Set([0, 24, 48]);
+      const quantToXFn = (q: number): number | null => (q === 24 ? null : 100 + q * 2);
+
+      // Should skip quant 24 since it returns null
+      // X=145 should snap to quant 48 (x=196) instead of quant 24
+      expect(xToNearestQuant(145, validQuants, quantToXFn, 100)).toBe(0); // x=100 is closer
+    });
+  });
+
+  describe('clientToSvg', () => {
+    it('transforms coordinates using fallback when CTM is null', () => {
+      // Create a mock SVG element where getScreenCTM returns null
+      const mockElement = {
+        ownerSVGElement: {
+          getScreenCTM: () => null,
+        },
+        parentElement: {
+          getScreenCTM: () => null,
+        },
+        getBoundingClientRect: () => ({ left: 50, top: 100 }),
+      } as unknown as SVGElement;
+
+      const result = clientToSvg(150, 200, mockElement);
+
+      // Fallback: clientX - rect.left, clientY - rect.top
+      expect(result.x).toBe(100); // 150 - 50
+      expect(result.y).toBe(100); // 200 - 100
+    });
+
+    it('transforms coordinates using fallback when svg is null', () => {
+      // Create a mock SVG element where ownerSVGElement is null and element itself has null CTM
+      const mockElement = {
+        ownerSVGElement: null,
+        parentElement: null,
+        getScreenCTM: () => null, // Element treated as SVGSVGElement needs this
+        getBoundingClientRect: () => ({ left: 25, top: 50 }),
+      } as unknown as SVGElement;
+
+      const result = clientToSvg(125, 150, mockElement);
+
+      // Fallback: clientX - rect.left, clientY - rect.top
+      expect(result.x).toBe(100); // 125 - 25
+      expect(result.y).toBe(100); // 150 - 50
+    });
+
+    // Note: Full CTM testing requires a real DOM/SVG context
+    // These tests would typically be integration tests with jsdom or a real browser
+  });
+});

--- a/src/__tests__/engines/layout/scoreLayout.test.ts
+++ b/src/__tests__/engines/layout/scoreLayout.test.ts
@@ -86,7 +86,7 @@ describe('calculateScoreLayout', () => {
 
     // Check note layout structure
     const firstNote = layout.notes[noteKeys[0]];
-    expect(firstNote).toHaveProperty('x');
+    expect(firstNote).toHaveProperty('localX');
     expect(firstNote).toHaveProperty('y');
     expect(firstNote).toHaveProperty('noteId');
     expect(firstNote).toHaveProperty('staffIndex');
@@ -142,8 +142,8 @@ describe('calculateScoreLayout', () => {
       if (note1.eventId === note2.eventId) {
         // X positions might be different for notes in the same chord
         // (though if they're perfectly aligned, they could be the same)
-        expect(typeof note1.x).toBe('number');
-        expect(typeof note2.x).toBe('number');
+        expect(typeof note1.localX).toBe('number');
+        expect(typeof note2.localX).toBe('number');
       }
     }
   });

--- a/src/__tests__/exporters/musicXmlExporter.test.ts
+++ b/src/__tests__/exporters/musicXmlExporter.test.ts
@@ -164,7 +164,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports basic major chord as harmony element', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'C' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'C' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<harmony>');
@@ -174,7 +174,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports minor chord correctly', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'Am' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Am' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>A</root-step>');
@@ -182,7 +182,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports dominant seventh chord correctly', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'G7' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'G7' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>G</root-step>');
@@ -190,7 +190,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports major seventh chord correctly', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'Cmaj7' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Cmaj7' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>C</root-step>');
@@ -198,7 +198,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports minor seventh chord correctly', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'Dm7' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Dm7' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>D</root-step>');
@@ -206,7 +206,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports diminished chord correctly', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'Bdim' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Bdim' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>B</root-step>');
@@ -214,7 +214,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports augmented chord correctly', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'Caug' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Caug' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>C</root-step>');
@@ -222,7 +222,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports half-diminished chord correctly', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'Bm7b5' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Bm7b5' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>B</root-step>');
@@ -230,7 +230,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports suspended fourth chord correctly', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'Dsus4' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Dsus4' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>D</root-step>');
@@ -238,7 +238,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports suspended second chord correctly', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'Gsus2' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Gsus2' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>G</root-step>');
@@ -246,7 +246,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports sharp root note with root-alter', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'F#m' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'F#m' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>F</root-step>');
@@ -255,7 +255,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports flat root note with root-alter', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'Bb7' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Bb7' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>B</root-step>');
@@ -264,7 +264,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports slash chord with bass element', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'C/E' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'C/E' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>C</root-step>');
@@ -275,7 +275,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('exports slash chord with accidental bass note', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'Am/G#' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Am/G#' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>A</root-step>');
@@ -285,7 +285,7 @@ describe('MusicXML Chord Symbol Export', () => {
 
   it('places harmony element before note at correct quant position', () => {
     // Chord at quant 16 (second quarter note)
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 16, symbol: 'G' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 16, symbol: 'G' }]);
     const xml = generateMusicXML(score);
 
     // Harmony should appear in the XML
@@ -299,8 +299,8 @@ describe('MusicXML Chord Symbol Export', () => {
 
   it('exports multiple chords at different positions', () => {
     const score = createScoreWithChords([
-      { id: 'chord-1', quant: 0, symbol: 'C' },
-      { id: 'chord-2', quant: 32, symbol: 'G' }, // Third beat
+      { id: 'chord-1', measure: 0, quant: 0, symbol: 'C' },
+      { id: 'chord-2', measure: 0, quant: 32, symbol: 'G' }, // Third beat
     ]);
     const xml = generateMusicXML(score);
 
@@ -315,7 +315,7 @@ describe('MusicXML Chord Symbol Export', () => {
       timeSignature: '4/4',
       keySignature: 'C',
       bpm: 120,
-      chordTrack: [{ id: 'chord-1', quant: 0, symbol: 'C' }],
+      chordTrack: [{ id: 'chord-1', measure: 0, quant: 0, symbol: 'C' }],
       staves: [
         {
           id: 'staff-1',
@@ -377,7 +377,7 @@ describe('MusicXML Chord Symbol Export', () => {
   });
 
   it('omits root-alter when root has no accidental', () => {
-    const score = createScoreWithChords([{ id: 'chord-1', quant: 0, symbol: 'C' }]);
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'C' }]);
     const xml = generateMusicXML(score);
 
     expect(xml).toContain('<root-step>C</root-step>');
@@ -393,8 +393,8 @@ describe('MusicXML Chord Symbol Export', () => {
       keySignature: 'C',
       bpm: 120,
       chordTrack: [
-        { id: 'chord-1', quant: 0, symbol: 'C' },
-        { id: 'chord-2', quant: 64, symbol: 'G' }, // First beat of measure 2
+        { id: 'chord-1', measure: 0, quant: 0, symbol: 'C' },
+        { id: 'chord-2', measure: 1, quant: 0, symbol: 'G' }, // First beat of measure 2
       ],
       staves: [
         {

--- a/src/__tests__/hooks/chord/useChordTrack.test.ts
+++ b/src/__tests__/hooks/chord/useChordTrack.test.ts
@@ -56,6 +56,7 @@ jest.mock('@/services/ChordService', () => ({
 
 const createTestChord = (overrides?: Partial<ChordSymbol>): ChordSymbol => ({
   id: 'chord-1',
+  measure: 0,
   quant: 0,
   symbol: 'Cmaj7',
   ...overrides,
@@ -140,10 +141,10 @@ describe('useChordTrack', () => {
         })
       );
 
-      expect(result.current.validQuants).toBeInstanceOf(Set);
+      expect(result.current.validPositions).toBeInstanceOf(Set);
       // With our mock, we expect beat positions (0, 24, 48, 72 per measure)
-      expect(result.current.validQuants.has(0)).toBe(true);
-      expect(result.current.validQuants.has(24)).toBe(true);
+      expect(result.current.validPositions.has(0)).toBe(true);
+      expect(result.current.validPositions.has(24)).toBe(true);
     });
 
     it('has null editing state initially', () => {
@@ -157,7 +158,7 @@ describe('useChordTrack', () => {
       );
 
       expect(result.current.editingChordId).toBeNull();
-      expect(result.current.creatingAtQuant).toBeNull();
+      expect(result.current.creatingAt).toBeNull();
       expect(result.current.initialValue).toBeNull();
     });
 
@@ -283,17 +284,17 @@ describe('useChordTrack', () => {
 
       // First start creating
       act(() => {
-        result.current.startCreating(48);
+        result.current.startCreating({ measure: 0, quant: 48 });
       });
 
-      expect(result.current.creatingAtQuant).toBe(48);
+      expect(result.current.creatingAt).toBe(48);
 
       // Then start editing
       act(() => {
         result.current.startEditing('chord-1');
       });
 
-      expect(result.current.creatingAtQuant).toBeNull();
+      expect(result.current.creatingAt).toBeNull();
       expect(result.current.editingChordId).toBe('chord-1');
     });
 
@@ -333,10 +334,10 @@ describe('useChordTrack', () => {
       );
 
       act(() => {
-        result.current.startCreating(24);
+        result.current.startCreating({ measure: 0, quant: 24 });
       });
 
-      expect(result.current.creatingAtQuant).toBe(24);
+      expect(result.current.creatingAt).toBe(24);
     });
 
     it('sets editingChordId to "new" for new chord creation', () => {
@@ -350,7 +351,7 @@ describe('useChordTrack', () => {
       );
 
       act(() => {
-        result.current.startCreating(0);
+        result.current.startCreating({ measure: 0, quant: 0 });
       });
 
       expect(result.current.editingChordId).toBe('new');
@@ -367,7 +368,7 @@ describe('useChordTrack', () => {
       );
 
       act(() => {
-        result.current.startCreating(72);
+        result.current.startCreating({ measure: 1, quant: 8 });
       });
 
       expect(result.current.initialValue).toBe('');
@@ -387,7 +388,7 @@ describe('useChordTrack', () => {
       );
 
       act(() => {
-        result.current.startCreating(48);
+        result.current.startCreating({ measure: 0, quant: 48 });
       });
 
       expect(selectionEngine.getState().chordId).toBeNull();
@@ -440,7 +441,7 @@ describe('useChordTrack', () => {
 
       // Start creating at quant 48
       act(() => {
-        result.current.startCreating(48);
+        result.current.startCreating({ measure: 0, quant: 48 });
       });
 
       // Complete with value (null chordId indicates new chord)
@@ -502,7 +503,7 @@ describe('useChordTrack', () => {
       });
 
       expect(result.current.editingChordId).toBeNull();
-      expect(result.current.creatingAtQuant).toBeNull();
+      expect(result.current.creatingAt).toBeNull();
       expect(result.current.initialValue).toBeNull();
     });
 
@@ -598,16 +599,16 @@ describe('useChordTrack', () => {
       );
 
       act(() => {
-        result.current.startCreating(24);
+        result.current.startCreating({ measure: 0, quant: 24 });
       });
 
-      expect(result.current.creatingAtQuant).toBe(24);
+      expect(result.current.creatingAt).toBe(24);
 
       act(() => {
         result.current.cancelEdit();
       });
 
-      expect(result.current.creatingAtQuant).toBeNull();
+      expect(result.current.creatingAt).toBeNull();
     });
 
     it('clears initialValue', () => {
@@ -884,7 +885,7 @@ describe('useChordTrack', () => {
         { initialProps: { score: scoreRef.current } }
       );
 
-      const _initialValidQuants = result.current.validQuants;
+      const _initialValidQuants = result.current.validPositions;
 
       // Create a new score (triggers recomputation)
       const newScore = createTestScore([]);
@@ -893,7 +894,7 @@ describe('useChordTrack', () => {
       rerender({ score: newScore });
 
       // validQuants should be recomputed (may be same values but new Set instance)
-      expect(result.current.validQuants).toBeInstanceOf(Set);
+      expect(result.current.validPositions).toBeInstanceOf(Set);
     });
   });
 });

--- a/src/__tests__/hooks/chord/useChordTrack.test.ts
+++ b/src/__tests__/hooks/chord/useChordTrack.test.ts
@@ -287,7 +287,7 @@ describe('useChordTrack', () => {
         result.current.startCreating({ measure: 0, quant: 48 });
       });
 
-      expect(result.current.creatingAt).toBe(48);
+      expect(result.current.creatingAt).toEqual({ measure: 0, quant: 48 });
 
       // Then start editing
       act(() => {
@@ -323,7 +323,7 @@ describe('useChordTrack', () => {
   // --------------------------------------------------------------------------
 
   describe('startCreating', () => {
-    it('sets creatingAtQuant to the target position', () => {
+    it('sets creatingAt to the target position', () => {
       const { result } = renderHook(() =>
         useChordTrack({
           scoreRef,
@@ -337,7 +337,7 @@ describe('useChordTrack', () => {
         result.current.startCreating({ measure: 0, quant: 24 });
       });
 
-      expect(result.current.creatingAt).toBe(24);
+      expect(result.current.creatingAt).toEqual({ measure: 0, quant: 24 });
     });
 
     it('sets editingChordId to "new" for new chord creation', () => {
@@ -449,7 +449,7 @@ describe('useChordTrack', () => {
         result.current.completeEdit(null, 'Dm');
       });
 
-      expect(AddChordCommand).toHaveBeenCalledWith(48, 'Dm');
+      expect(AddChordCommand).toHaveBeenCalledWith({ measure: 0, quant: 48 }, 'Dm');
       expect(mockDispatch).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'AddChordCommand' })
       );
@@ -602,7 +602,7 @@ describe('useChordTrack', () => {
         result.current.startCreating({ measure: 0, quant: 24 });
       });
 
-      expect(result.current.creatingAt).toBe(24);
+      expect(result.current.creatingAt).toEqual({ measure: 0, quant: 24 });
 
       act(() => {
         result.current.cancelEdit();

--- a/src/__tests__/hooks/layout/useCursorLayout.test.ts
+++ b/src/__tests__/hooks/layout/useCursorLayout.test.ts
@@ -6,13 +6,37 @@
  */
 import { renderHook } from '@testing-library/react';
 import { useCursorLayout } from '@/hooks/layout/useCursorLayout';
-import { ScoreLayout, StaffLayout } from '@/engines/layout/types';
+import { ScoreLayout, StaffLayout, YBounds } from '@/engines/layout/types';
+import { CONFIG } from '@/config';
+
+// Helper to create mock getX function matching the new API
+const createMockGetX = (measureOrigins: number[] = []) => {
+  const getX = (_params: { measure: number; quant: number }): number | null => null;
+  getX.measureOrigin = (params: { measure: number }): number | null =>
+    measureOrigins[params.measure] ?? null;
+  return getX;
+};
+
+// Helper to create mock getY function
+const createMockGetY = (): ScoreLayout['getY'] => {
+  const staffHeight = CONFIG.lineHeight * 4;
+  const bounds: YBounds = { top: CONFIG.baseY, bottom: CONFIG.baseY + staffHeight };
+  return {
+    content: bounds,
+    system: (index: number) => (index === 0 ? bounds : null),
+    staff: (index: number) => (index === 0 ? bounds : null),
+    notes: () => bounds,
+    pitch: () => null,
+  };
+};
 
 describe('useCursorLayout', () => {
   const createEmptyLayout = (): ScoreLayout => ({
     staves: [],
     notes: {},
     events: {},
+    getX: createMockGetX(),
+    getY: createMockGetY(),
   });
 
   const createSingleStaffLayout = (): ScoreLayout => ({
@@ -42,6 +66,8 @@ describe('useCursorLayout', () => {
     ],
     notes: {},
     events: {},
+    getX: createMockGetX([80]),
+    getY: createMockGetY(),
   });
 
   const createGrandStaffLayout = (): ScoreLayout => ({
@@ -102,6 +128,8 @@ describe('useCursorLayout', () => {
     ],
     notes: {},
     events: {},
+    getX: createMockGetX([80, 200]),
+    getY: createMockGetY(),
   });
 
   describe('basic behavior', () => {
@@ -237,6 +265,8 @@ describe('useCursorLayout', () => {
         ],
         notes: {},
         events: {},
+        getX: createMockGetX([80]),
+        getY: createMockGetY(),
       };
 
       const { result } = renderHook(() =>
@@ -297,6 +327,8 @@ describe('useCursorLayout', () => {
         ],
         notes: {},
         events: {},
+        getX: createMockGetX([80]),
+        getY: createMockGetY(),
       };
 
       const { result } = renderHook(() =>

--- a/src/__tests__/services/ChordService.test.ts
+++ b/src/__tests__/services/ChordService.test.ts
@@ -662,16 +662,18 @@ describe('ChordService - Valid Quant Calculation', () => {
   });
 
   describe('getValidChordQuants', () => {
-    it('returns empty set for empty score', () => {
+    it('returns map with empty sets for score with no events', () => {
       const score = createTestScore([]);
-      const validQuants = getValidChordQuants(score);
-      expect(validQuants.size).toBe(0);
+      const validPositions = getValidChordQuants(score);
+      // Map has entries for measures, but sets are empty when no events
+      const measure0Quants = validPositions.get(0);
+      expect(measure0Quants?.size ?? 0).toBe(0);
     });
 
     it('returns quant 0 for single note at start', () => {
       const score = createTestScore([{ duration: 'quarter' }]);
-      const validQuants = getValidChordQuants(score);
-      expect(validQuants.has(0)).toBe(true);
+      const validPositions = getValidChordQuants(score);
+      expect(validPositions.get(0)?.has(0)).toBe(true);
     });
 
     it('calculates correct quants for quarter notes', () => {
@@ -682,11 +684,12 @@ describe('ChordService - Valid Quant Calculation', () => {
         { duration: 'quarter' },
         { duration: 'quarter' },
       ]);
-      const validQuants = getValidChordQuants(score);
-      expect(validQuants.has(0)).toBe(true);
-      expect(validQuants.has(16)).toBe(true);
-      expect(validQuants.has(32)).toBe(true);
-      expect(validQuants.has(48)).toBe(true);
+      const validPositions = getValidChordQuants(score);
+      const measure0Quants = validPositions.get(0);
+      expect(measure0Quants?.has(0)).toBe(true);
+      expect(measure0Quants?.has(16)).toBe(true);
+      expect(measure0Quants?.has(32)).toBe(true);
+      expect(measure0Quants?.has(48)).toBe(true);
     });
 
     it('includes rest positions as valid chord anchors', () => {
@@ -695,10 +698,11 @@ describe('ChordService - Valid Quant Calculation', () => {
         { duration: 'quarter', isRest: true }, // quant 16 - rest, also valid
         { duration: 'quarter' }, // quant 32 - valid
       ]);
-      const validQuants = getValidChordQuants(score);
-      expect(validQuants.has(0)).toBe(true);
-      expect(validQuants.has(16)).toBe(true); // rests are valid anchor points
-      expect(validQuants.has(32)).toBe(true);
+      const validPositions = getValidChordQuants(score);
+      const measure0Quants = validPositions.get(0);
+      expect(measure0Quants?.has(0)).toBe(true);
+      expect(measure0Quants?.has(16)).toBe(true); // rests are valid anchor points
+      expect(measure0Quants?.has(32)).toBe(true);
     });
 
     it('handles multiple staves', () => {
@@ -748,11 +752,12 @@ describe('ChordService - Valid Quant Calculation', () => {
         ],
       };
 
-      const validQuants = getValidChordQuants(score);
+      const validPositions = getValidChordQuants(score);
       // Staff 1: half note at quant 0
       // Staff 2: quarter note at quant 0, quarter note at quant 16
-      expect(validQuants.has(0)).toBe(true);
-      expect(validQuants.has(16)).toBe(true);
+      const measure0Quants = validPositions.get(0);
+      expect(measure0Quants?.has(0)).toBe(true);
+      expect(measure0Quants?.has(16)).toBe(true);
     });
 
     it('handles multiple measures', () => {
@@ -794,11 +799,11 @@ describe('ChordService - Valid Quant Calculation', () => {
         ],
       };
 
-      const validQuants = getValidChordQuants(score);
-      // Measure 1: quant 0
-      // Measure 2: quant 64 (64 quants per 4/4 measure)
-      expect(validQuants.has(0)).toBe(true);
-      expect(validQuants.has(64)).toBe(true);
+      const validPositions = getValidChordQuants(score);
+      // Measure 0: quant 0
+      // Measure 1: quant 0 (each measure starts fresh)
+      expect(validPositions.get(0)?.has(0)).toBe(true);
+      expect(validPositions.get(1)?.has(0)).toBe(true);
     });
 
     it('handles dotted notes correctly', () => {
@@ -835,10 +840,11 @@ describe('ChordService - Valid Quant Calculation', () => {
         ],
       };
 
-      const validQuants = getValidChordQuants(score);
+      const validPositions = getValidChordQuants(score);
       // Dotted quarter = 24 quants (16 * 1.5), followed by eighth at quant 24
-      expect(validQuants.has(0)).toBe(true);
-      expect(validQuants.has(24)).toBe(true);
+      const measure0Quants = validPositions.get(0);
+      expect(measure0Quants?.has(0)).toBe(true);
+      expect(measure0Quants?.has(24)).toBe(true);
     });
   });
 });

--- a/src/api.types.ts
+++ b/src/api.types.ts
@@ -490,12 +490,12 @@ export interface MusicEditorAPI {
 
   // --- Chord CRUD Operations ---
   /**
-   * Add a chord symbol at the specified quant position.
-   * @param quant - Global quant position for the chord
+   * Add a chord symbol at the specified position.
+   * @param position - Position as { measure, quant }
    * @param symbol - Chord symbol string (e.g., 'Cmaj7', 'Dm', 'G7')
    * @status implemented
    */
-  addChord(quant: number, symbol: string): this;
+  addChord(position: { measure: number; quant: number }, symbol: string): this;
   /**
    * Update an existing chord symbol.
    * @param chordId - ID of the chord to update
@@ -511,7 +511,7 @@ export interface MusicEditorAPI {
   removeChord(chordId: string): this;
   /**
    * Get all chord symbols in the score.
-   * @returns Array of chord symbols sorted by quant ascending
+   * @returns Array of chord symbols sorted by position ascending
    * @status implemented
    */
   getChords(): ChordSymbol[];
@@ -523,18 +523,18 @@ export interface MusicEditorAPI {
    */
   getChord(chordId: string): ChordSymbol | null;
   /**
-   * Get the chord at a specific quant position.
-   * @param quant - Global quant position
+   * Get the chord at a specific position.
+   * @param position - Position as { measure, quant }
    * @returns The chord at that position or null if none exists
    * @status implemented
    */
-  getChordAtQuant(quant: number): ChordSymbol | null;
+  getChordAt(position: { measure: number; quant: number }): ChordSymbol | null;
   /**
-   * Get all valid quant positions where chords can be placed.
-   * @returns Array of valid quant positions
+   * Get all valid positions where chords can be placed.
+   * @returns Map of measure index to set of valid local quants
    * @status implemented
    */
-  getValidChordQuants(): number[];
+  getValidChordPositions(): Map<number, Set<number>>;
 
   // --- Chord Selection ---
   /**
@@ -544,11 +544,11 @@ export interface MusicEditorAPI {
    */
   selectChord(chordId: string): this;
   /**
-   * Select the chord at a specific quant position.
-   * @param quant - Global quant position
+   * Select the chord at a specific position.
+   * @param position - Position as { measure, quant }
    * @status implemented
    */
-  selectChordAtQuant(quant: number): this;
+  selectChordAt(position: { measure: number; quant: number }): this;
   /**
    * Deselect the currently selected chord.
    * @status implemented

--- a/src/commands/chord/AddChordCommand.ts
+++ b/src/commands/chord/AddChordCommand.ts
@@ -84,9 +84,7 @@ export class AddChordCommand implements Command {
   execute(score: Score): Score {
     return updateChordTrack(score, (chordTrack) => {
       // Find insert position (sorted by measure, then quant)
-      this.insertIndex = chordTrack.findIndex(
-        (c) => compareChordPositions(c, this.chord) >= 0
-      );
+      this.insertIndex = chordTrack.findIndex((c) => compareChordPositions(c, this.chord) >= 0);
 
       if (this.insertIndex === -1) {
         // Append at end

--- a/src/commands/chord/AddChordCommand.ts
+++ b/src/commands/chord/AddChordCommand.ts
@@ -3,22 +3,50 @@ import { Score, ChordSymbol } from '@/types';
 import { chordId } from '@/utils/id';
 import { updateChordTrack } from '@/utils/commandHelpers';
 
+/** Position for chord placement */
+export interface ChordPosition {
+  measure: number;
+  quant: number;
+}
+
 /**
- * Add a chord symbol at a specific quant position.
+ * Compare two chord positions for sorting.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ */
+export const compareChordPositions = (
+  a: { measure: number; quant: number },
+  b: { measure: number; quant: number }
+): number => {
+  if (a.measure !== b.measure) return a.measure - b.measure;
+  return a.quant - b.quant;
+};
+
+/**
+ * Check if two chord positions are equal.
+ */
+export const positionsEqual = (
+  a: { measure: number; quant: number },
+  b: { measure: number; quant: number }
+): boolean => {
+  return a.measure === b.measure && a.quant === b.quant;
+};
+
+/**
+ * Add a chord symbol at a specific measure-local position.
  *
- * If a chord already exists at that quant, it is replaced.
- * The chord track is kept sorted by quant position.
+ * If a chord already exists at that position, it is replaced.
+ * The chord track is kept sorted by measure, then by quant.
  *
  * @example
  * ```typescript
- * // Add a C major chord at beat 1
- * dispatch(new AddChordCommand(0, 'C'));
+ * // Add a C major chord at measure 0, beat 1
+ * dispatch(new AddChordCommand({ measure: 0, quant: 0 }, 'C'));
  *
- * // Add with custom ID
- * dispatch(new AddChordCommand(24, 'G7', 'chord_custom_123'));
+ * // Add at measure 1, beat 2 with custom ID
+ * dispatch(new AddChordCommand({ measure: 1, quant: 16 }, 'G7', 'chord_custom_123'));
  * ```
  *
- * @throws {Error} If quant is negative
+ * @throws {Error} If measure or quant is negative
  * @throws {Error} If symbol is empty after trimming
  *
  * @tested src/__tests__/commands/chord/ChordCommands.test.ts
@@ -30,29 +58,41 @@ export class AddChordCommand implements Command {
   private replacedChord: ChordSymbol | null = null;
 
   /**
-   * @param quant - Global quant position (must be >= 0)
+   * @param position - Measure-local position { measure, quant }
    * @param symbol - Chord symbol string (e.g., 'C', 'Dm7', 'G/B')
    * @param id - Optional chord ID (auto-generated if omitted)
    */
-  constructor(quant: number, symbol: string, id?: string) {
-    if (quant < 0) {
-      throw new Error(`AddChordCommand: quant must be >= 0, got ${quant}`);
+  constructor(position: ChordPosition, symbol: string, id?: string) {
+    if (position.measure < 0) {
+      throw new Error(`AddChordCommand: measure must be >= 0, got ${position.measure}`);
+    }
+    if (position.quant < 0) {
+      throw new Error(`AddChordCommand: quant must be >= 0, got ${position.quant}`);
     }
     const trimmedSymbol = symbol.trim();
     if (!trimmedSymbol) {
       throw new Error('AddChordCommand: symbol cannot be empty');
     }
-    this.chord = { id: id ?? chordId(), quant, symbol: trimmedSymbol };
+    this.chord = {
+      id: id ?? chordId(),
+      measure: position.measure,
+      quant: position.quant,
+      symbol: trimmedSymbol,
+    };
   }
 
   execute(score: Score): Score {
     return updateChordTrack(score, (chordTrack) => {
-      this.insertIndex = chordTrack.findIndex((c) => c.quant >= this.chord.quant);
+      // Find insert position (sorted by measure, then quant)
+      this.insertIndex = chordTrack.findIndex(
+        (c) => compareChordPositions(c, this.chord) >= 0
+      );
+
       if (this.insertIndex === -1) {
         // Append at end
         this.insertIndex = chordTrack.length;
         chordTrack.push(this.chord);
-      } else if (chordTrack[this.insertIndex].quant === this.chord.quant) {
+      } else if (positionsEqual(chordTrack[this.insertIndex], this.chord)) {
         // Replace existing chord at same position
         this.replacedChord = chordTrack[this.insertIndex];
         chordTrack[this.insertIndex] = this.chord;

--- a/src/commands/chord/UpdateChordCommand.ts
+++ b/src/commands/chord/UpdateChordCommand.ts
@@ -1,43 +1,47 @@
 import { Command } from '../types';
 import { Score, ChordSymbol } from '@/types';
 import { updateChordTrack } from '@/utils/commandHelpers';
+import { compareChordPositions } from './AddChordCommand';
+
+/** Fields that can be updated on a chord */
+export type ChordUpdates = Partial<Pick<ChordSymbol, 'symbol' | 'measure' | 'quant'>>;
 
 /**
  * Update an existing chord symbol.
  *
- * Supports updating the symbol text and/or quant position.
- * If quant is changed, the chord track is re-sorted.
+ * Supports updating the symbol text, measure, and/or quant position.
+ * If measure or quant is changed, the chord track is re-sorted.
  *
  * @example
  * ```typescript
  * // Change chord symbol
  * dispatch(new UpdateChordCommand('chord_123', { symbol: 'Dm7' }));
  *
- * // Move chord to different position
+ * // Move chord to different position in same measure
  * dispatch(new UpdateChordCommand('chord_123', { quant: 48 }));
  *
- * // Update both
- * dispatch(new UpdateChordCommand('chord_123', { symbol: 'Em', quant: 72 }));
+ * // Move chord to different measure
+ * dispatch(new UpdateChordCommand('chord_123', { measure: 2, quant: 0 }));
  * ```
  *
  * @throws {Error} If chordId is empty
  * @throws {Error} If updates.symbol is provided but empty after trimming
- * @throws {Error} If updates.quant is negative
+ * @throws {Error} If updates.measure or updates.quant is negative
  *
  * @tested src/__tests__/commands/chord/ChordCommands.test.ts
  */
 export class UpdateChordCommand implements Command {
   readonly type = 'UPDATE_CHORD';
   private previousChord: ChordSymbol | null = null;
-  private validatedUpdates: Partial<Pick<ChordSymbol, 'symbol' | 'quant'>>;
+  private validatedUpdates: ChordUpdates;
 
   /**
    * @param chordId - ID of the chord to update
-   * @param updates - Properties to update (symbol and/or quant)
+   * @param updates - Properties to update (symbol, measure, and/or quant)
    */
   constructor(
     private chordId: string,
-    updates: Partial<Pick<ChordSymbol, 'symbol' | 'quant'>>
+    updates: ChordUpdates
   ) {
     if (!chordId || !chordId.trim()) {
       throw new Error('UpdateChordCommand: chordId cannot be empty');
@@ -48,6 +52,9 @@ export class UpdateChordCommand implements Command {
         throw new Error('UpdateChordCommand: symbol cannot be empty');
       }
       updates = { ...updates, symbol: trimmed };
+    }
+    if (updates.measure !== undefined && updates.measure < 0) {
+      throw new Error(`UpdateChordCommand: measure must be >= 0, got ${updates.measure}`);
     }
     if (updates.quant !== undefined && updates.quant < 0) {
       throw new Error(`UpdateChordCommand: quant must be >= 0, got ${updates.quant}`);
@@ -66,9 +73,9 @@ export class UpdateChordCommand implements Command {
       // Apply validated updates
       chordTrack[idx] = { ...chordTrack[idx], ...this.validatedUpdates };
 
-      // If quant changed, re-sort the chord track
-      if (this.validatedUpdates.quant !== undefined) {
-        chordTrack.sort((a, b) => a.quant - b.quant);
+      // If position changed, re-sort the chord track
+      if (this.validatedUpdates.measure !== undefined || this.validatedUpdates.quant !== undefined) {
+        chordTrack.sort(compareChordPositions);
       }
 
       return chordTrack;
@@ -85,9 +92,9 @@ export class UpdateChordCommand implements Command {
       // Restore previous state
       chordTrack[idx] = { ...this.previousChord! };
 
-      // Re-sort if quant was changed
-      if (this.validatedUpdates.quant !== undefined) {
-        chordTrack.sort((a, b) => a.quant - b.quant);
+      // Re-sort if position was changed
+      if (this.validatedUpdates.measure !== undefined || this.validatedUpdates.quant !== undefined) {
+        chordTrack.sort(compareChordPositions);
       }
 
       return chordTrack;

--- a/src/commands/chord/UpdateChordCommand.ts
+++ b/src/commands/chord/UpdateChordCommand.ts
@@ -74,7 +74,10 @@ export class UpdateChordCommand implements Command {
       chordTrack[idx] = { ...chordTrack[idx], ...this.validatedUpdates };
 
       // If position changed, re-sort the chord track
-      if (this.validatedUpdates.measure !== undefined || this.validatedUpdates.quant !== undefined) {
+      if (
+        this.validatedUpdates.measure !== undefined ||
+        this.validatedUpdates.quant !== undefined
+      ) {
         chordTrack.sort(compareChordPositions);
       }
 
@@ -93,7 +96,10 @@ export class UpdateChordCommand implements Command {
       chordTrack[idx] = { ...this.previousChord! };
 
       // Re-sort if position was changed
-      if (this.validatedUpdates.measure !== undefined || this.validatedUpdates.quant !== undefined) {
+      if (
+        this.validatedUpdates.measure !== undefined ||
+        this.validatedUpdates.quant !== undefined
+      ) {
         chordTrack.sort(compareChordPositions);
       }
 

--- a/src/components/Assets/NoteIcon.tsx
+++ b/src/components/Assets/NoteIcon.tsx
@@ -1,9 +1,9 @@
 // @ts-nocheck
 import React from 'react';
 import { PRECOMPOSED_NOTES_UP, BRAVURA_FONT } from '@/constants/SMuFL';
+import { CONFIG } from '@/config';
 
-// Icon viewport size (scaled down from 24 to 20)
-const ICON_SIZE = 20;
+const ICON_SIZE = CONFIG.toolbar.iconSize;
 
 // Custom sizing for notes that need adjustment (scaled by ~0.83)
 const NOTE_SIZING = {

--- a/src/components/Assets/RestIcon.tsx
+++ b/src/components/Assets/RestIcon.tsx
@@ -1,9 +1,9 @@
 // @ts-nocheck
 import React from 'react';
 import { REST_GLYPHS, BRAVURA_FONT } from '@/constants/SMuFL';
+import { CONFIG } from '@/config';
 
-// Icon viewport size (scaled down from 24 to 20)
-const ICON_SIZE = 20;
+const ICON_SIZE = CONFIG.toolbar.iconSize;
 
 /**
  * Renders rest glyphs for toolbar display using Bravura font.

--- a/src/components/Canvas/ChordTrack/ChordTrack.tsx
+++ b/src/components/Canvas/ChordTrack/ChordTrack.tsx
@@ -16,7 +16,6 @@ import { ChordSymbol } from './ChordSymbol';
 import { ChordInput } from './ChordInput';
 import './ChordTrack.css';
 
-
 // ============================================================================
 // TYPES
 // ============================================================================
@@ -112,10 +111,7 @@ function getBeatPosition(measure: number, quant: number): string {
  * Get X position for a chord position using measure-relative layout.
  * Returns absolute X by combining measureOrigin and local X.
  */
-function getAbsoluteX(
-  position: ChordPosition,
-  layout: ScoreLayout
-): number {
+function getAbsoluteX(position: ChordPosition, layout: ScoreLayout): number {
   const measureOrigin = layout.getX.measureOrigin({ measure: position.measure }) ?? 0;
   const localX = layout.getX({ measure: position.measure, quant: position.quant }) ?? 0;
   return measureOrigin + localX;

--- a/src/components/Canvas/ScoreCanvas.tsx
+++ b/src/components/Canvas/ScoreCanvas.tsx
@@ -505,13 +505,13 @@ const ScoreCanvas: React.FC<ScoreCanvasProps> = ({
             displayConfig={DEFAULT_CHORD_DISPLAY}
             keySignature={keySignature}
             timeSignature={timeSignature}
-            validQuants={chordTrackHook.validQuants}
+            validPositions={chordTrackHook.validPositions}
             measurePositions={measurePositions}
             layout={layout}
             quantsPerMeasure={quantsPerMeasure}
             editingChordId={chordTrackHook.editingChordId}
             selectedChordId={chordTrackHook.selectedChordId}
-            creatingAtQuant={chordTrackHook.creatingAtQuant}
+            creatingAt={chordTrackHook.creatingAt}
             initialValue={chordTrackHook.initialValue}
             onChordClick={(chordId) => {
               // Click goes directly to edit mode

--- a/src/components/Canvas/ScoreCanvas.tsx
+++ b/src/components/Canvas/ScoreCanvas.tsx
@@ -239,7 +239,7 @@ const ScoreCanvas: React.FC<ScoreCanvasProps> = ({
     duration: playbackPosition.duration,
   };
 
-  const { measure: cursorMeasure, x: cursorLocalX, numStaves } = useCursorLayout(
+  const { measure: cursorMeasure, x: cursorLocalX } = useCursorLayout(
     layout,
     effectivePlaybackPos,
     isPlaying
@@ -456,7 +456,11 @@ const ScoreCanvas: React.FC<ScoreCanvasProps> = ({
                 const systemBounds = layout.getY.system(0);
                 if (!systemBounds) return null;
                 return (
-                  <GrandStaffBracket topY={systemBounds.top} bottomY={systemBounds.bottom} x={-20} />
+                  <GrandStaffBracket
+                    topY={systemBounds.top}
+                    bottomY={systemBounds.bottom}
+                    x={-20}
+                  />
                 );
               })()}
             </>
@@ -648,7 +652,8 @@ const ScoreCanvas: React.FC<ScoreCanvasProps> = ({
               setTimeout(() => {
                 const updatedChords = chordTrackHook.chords;
                 const chordAtPosition = updatedChords.find(
-                  (c) => c.measure === previousPosition.measure && c.quant === previousPosition.quant
+                  (c) =>
+                    c.measure === previousPosition.measure && c.quant === previousPosition.quant
                 );
 
                 if (chordAtPosition) {
@@ -663,9 +668,7 @@ const ScoreCanvas: React.FC<ScoreCanvasProps> = ({
             onDelete={(chordId) => {
               // Get the chord's position before deletion for focus restoration
               const chord = chordTrackHook.chords.find((c) => c.id === chordId);
-              const chordPosition = chord
-                ? { measure: chord.measure, quant: chord.quant }
-                : null;
+              const chordPosition = chord ? { measure: chord.measure, quant: chord.quant } : null;
 
               // Delete the chord
               chordTrackHook.deleteChord(chordId);
@@ -689,25 +692,26 @@ const ScoreCanvas: React.FC<ScoreCanvasProps> = ({
               }}
             >
               {(() => {
-              const systemBounds = layout.getY.system(0);
-              const cursorTop = (systemBounds?.top ?? CONFIG.baseY) - 20;
-              const cursorBottom = (systemBounds?.bottom ?? CONFIG.baseY + CONFIG.lineHeight * 4) + 20;
-              return (
-                <>
-                  <line
-                    x1={0}
-                    y1={cursorTop}
-                    x2={0}
-                    y2={cursorBottom}
-                    stroke={theme.accent}
-                    strokeWidth="3"
-                    opacity="0.8"
-                  />
-                  <circle cx={0} cy={cursorTop} r="4" fill={theme.accent} opacity="0.9" />
-                  <circle cx={0} cy={cursorBottom} r="4" fill={theme.accent} opacity="0.9" />
-                </>
-              );
-            })()}
+                const systemBounds = layout.getY.system(0);
+                const cursorTop = (systemBounds?.top ?? CONFIG.baseY) - 20;
+                const cursorBottom =
+                  (systemBounds?.bottom ?? CONFIG.baseY + CONFIG.lineHeight * 4) + 20;
+                return (
+                  <>
+                    <line
+                      x1={0}
+                      y1={cursorTop}
+                      x2={0}
+                      y2={cursorBottom}
+                      stroke={theme.accent}
+                      strokeWidth="3"
+                      opacity="0.8"
+                    />
+                    <circle cx={0} cy={cursorTop} r="4" fill={theme.accent} opacity="0.9" />
+                    <circle cx={0} cy={cursorBottom} r="4" fill={theme.accent} opacity="0.9" />
+                  </>
+                );
+              })()}
             </g>
           )}
 

--- a/src/components/Canvas/ScoreHeader.tsx
+++ b/src/components/Canvas/ScoreHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { KEY_SIGNATURES, KEY_SIGNATURE_OFFSETS, KeySignatureOffsets } from '@/constants';
 import { CONFIG } from '@/config';
 import { useTheme } from '@/context/ThemeContext';
-import { calculateHeaderLayout, HEADER_CONSTANTS } from '@/engines/layout';
+import { calculateHeaderLayout } from '@/engines/layout';
 import { ACCIDENTALS, CLEFS, TIME_SIG_DIGITS, BRAVURA_FONT, getFontSize } from '@/constants/SMuFL';
 
 interface ScoreHeaderProps {
@@ -69,9 +69,7 @@ const ScoreHeader: React.FC<ScoreHeaderProps> = ({
   // Use centralized layout calculation (SSOT)
   const headerLayout = calculateHeaderLayout(keySignature);
   const { keySigStartX, keySigVisualWidth, timeSigStartX, startOfMeasures } = headerLayout;
-  const { KEY_SIG_ACCIDENTAL_WIDTH, TIME_SIG_WIDTH } = HEADER_CONSTANTS;
-
-  const CLEF_WIDTH = 40;
+  const { keySigAccidentalWidth, timeSigWidth, clefWidth } = CONFIG.header;
 
   return (
     <g className="ScoreHeader">
@@ -98,7 +96,7 @@ const ScoreHeader: React.FC<ScoreHeaderProps> = ({
 
       {/* Clef - clickable */}
       <g onClick={onClefClick} style={{ cursor: 'pointer' }} data-testid={`clef-${clef}`}>
-        <rect x="-5" y={baseY - 25} width={CLEF_WIDTH} height="100" fill="transparent" />
+        <rect x="-5" y={baseY - 25} width={clefWidth} height="100" fill="transparent" />
         <text
           x={12}
           y={getClefY(clef, baseY)}
@@ -130,7 +128,7 @@ const ScoreHeader: React.FC<ScoreHeaderProps> = ({
           const validClef =
             clef in KEY_SIGNATURE_OFFSETS ? (clef as keyof KeySignatureOffsets) : 'treble';
           const offset = KEY_SIGNATURE_OFFSETS[validClef][type][acc];
-          const x = keySigStartX + 5 + i * KEY_SIG_ACCIDENTAL_WIDTH;
+          const x = keySigStartX + 5 + i * keySigAccidentalWidth;
           const y = baseY + offset;
 
           return (
@@ -150,7 +148,7 @@ const ScoreHeader: React.FC<ScoreHeaderProps> = ({
 
       {/* Time Signature */}
       <g onClick={onTimeSigClick} style={{ cursor: 'pointer', userSelect: 'none' }}>
-        <rect x={timeSigStartX} y={baseY} width={TIME_SIG_WIDTH} height="48" fill="transparent" />
+        <rect x={timeSigStartX} y={baseY} width={timeSigWidth} height="48" fill="transparent" />
         <text
           x={timeSigStartX + 15}
           y={baseY + CONFIG.lineHeight}

--- a/src/components/Toolbar/AccidentalControls.tsx
+++ b/src/components/Toolbar/AccidentalControls.tsx
@@ -6,11 +6,11 @@
  */
 import React from 'react';
 import { ACCIDENTALS, BRAVURA_FONT } from '@/constants/SMuFL';
+import { CONFIG } from '@/config';
 import ToolbarButton from './ToolbarButton';
 
-// SVG viewport and font size for compact toolbar icons
-const ICON_SIZE = 20;
-const FONT_SIZE = 20;
+const ICON_SIZE = CONFIG.toolbar.iconSize;
+const FONT_SIZE = CONFIG.toolbar.iconSize;
 
 interface AccidentalIconProps {
   type: 'flat' | 'natural' | 'sharp';

--- a/src/components/Toolbar/InputModeToggle.tsx
+++ b/src/components/Toolbar/InputModeToggle.tsx
@@ -6,9 +6,9 @@
 import React from 'react';
 import { useTheme } from '@/context/ThemeContext';
 import { RESTS, NOTEHEADS, BRAVURA_FONT } from '@/constants/SMuFL';
+import { CONFIG } from '@/config';
 
-// Icon viewport size (scaled down from 24 to 20)
-const ICON_SIZE = 20;
+const ICON_SIZE = CONFIG.toolbar.iconSize;
 
 /**
  * Input mode for the toolbar - determines whether clicks/keyboard

--- a/src/components/Toolbar/MeasureControls.tsx
+++ b/src/components/Toolbar/MeasureControls.tsx
@@ -6,9 +6,9 @@
  */
 import React from 'react';
 import ToolbarButton from './ToolbarButton';
+import { CONFIG } from '@/config';
 
-// SVG viewport size for compact toolbar icons
-const ICON_SIZE = 20;
+const ICON_SIZE = CONFIG.toolbar.iconSize;
 
 /**
  * Add Measure Icon - Final barline with a plus

--- a/src/components/Toolbar/ModifierControls.tsx
+++ b/src/components/Toolbar/ModifierControls.tsx
@@ -8,9 +8,9 @@ import React from 'react';
 import TieIcon from '../Assets/TieIcon';
 import ToolbarButton from './ToolbarButton';
 import { DOTS, BRAVURA_FONT } from '@/constants/SMuFL';
+import { CONFIG } from '@/config';
 
-// SVG viewport and font size for compact toolbar icons
-const ICON_SIZE = 20;
+const ICON_SIZE = CONFIG.toolbar.iconSize;
 
 /**
  * Bravura-based augmentation dot icon for toolbar

--- a/src/components/Toolbar/TupletControls.tsx
+++ b/src/components/Toolbar/TupletControls.tsx
@@ -6,11 +6,11 @@
 import React from 'react';
 import ToolbarButton from './ToolbarButton';
 import { TUPLETS, BRAVURA_FONT } from '@/constants/SMuFL';
+import { CONFIG } from '@/config';
 
 import './styles/TupletControls.css';
 
-// SVG viewport size for compact toolbar icons
-const ICON_SIZE = 20;
+const ICON_SIZE = CONFIG.toolbar.iconSize;
 
 /**
  * SMuFL-based tuplet number icon with noteheads representing the group

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,38 @@ export interface Config {
   headerWidth: number;
   staffSpacing: number;
 
+  // Chord track positioning
+  chordTrack: {
+    /** Minimum distance above staff top line */
+    minDistanceFromStaff: number;
+    /** Gap between highest note and chord symbol */
+    paddingAboveNotes: number;
+    /** Absolute minimum Y position (top of canvas) */
+    minY: number;
+  };
+
+  // Toolbar sizing
+  toolbar: {
+    /** Icon size for toolbar buttons */
+    iconSize: number;
+  };
+
+  // Header layout (clef, key sig, time sig)
+  header: {
+    /** Clef symbol width */
+    clefWidth: number;
+    /** X position where key signature starts */
+    keySigStartX: number;
+    /** Width per accidental in key signature */
+    keySigAccidentalWidth: number;
+    /** Padding after key signature */
+    keySigPadding: number;
+    /** Time signature width */
+    timeSigWidth: number;
+    /** Padding after time signature */
+    timeSigPadding: number;
+  };
+
   debug?: {
     enabled: boolean;
     logCommands: boolean;
@@ -40,6 +72,25 @@ export const CONFIG: Config = {
   scoreMarginLeft: 60,
   headerWidth: 60,
   staffSpacing: 120,
+
+  chordTrack: {
+    minDistanceFromStaff: 40,
+    paddingAboveNotes: 20,
+    minY: 0,
+  },
+
+  toolbar: {
+    iconSize: 20,
+  },
+
+  header: {
+    clefWidth: 40,
+    keySigStartX: 45,
+    keySigAccidentalWidth: 10,
+    keySigPadding: 10,
+    timeSigWidth: 30,
+    timeSigPadding: 20,
+  },
 
   debug: {
     enabled: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -347,6 +347,9 @@ export const LAYOUT = {
     SPACING: HALF_SPACE + 2,
   },
 
+  /** Padding added before noteheads when accidentals are present */
+  ACCIDENTAL_PADDING: NOTE_SPACING_BASE_UNIT * 0.8,
+
   // Hit Detection
   HIT_AREA: {
     WIDTH: 20,

--- a/src/engines/layout/coordinateUtils.ts
+++ b/src/engines/layout/coordinateUtils.ts
@@ -1,0 +1,98 @@
+/**
+ * coordinateUtils.ts
+ *
+ * Shared coordinate transformation utilities for score layout.
+ * All X position logic flows through these functions.
+ *
+ * @see Issue #204
+ */
+
+/** Simple 2D point */
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** Measure position data for interpolation fallback */
+export interface MeasurePosition {
+  x: number;
+  width: number;
+}
+
+/**
+ * Convert quant to X coordinate.
+ * Two-stage lookup: exact match from map, then interpolation fallback.
+ */
+export function quantToX(
+  quant: number,
+  quantToXMap: Map<number, number>,
+  measurePositions: MeasurePosition[],
+  quantsPerMeasure: number
+): number | null {
+  // Stage 1: Exact match (O(1) lookup)
+  const exact = quantToXMap.get(quant);
+  if (exact !== undefined) return exact;
+
+  // Stage 2: Interpolation fallback
+  if (measurePositions.length === 0) return null;
+
+  const measureIndex = Math.floor(quant / quantsPerMeasure);
+  const measure = measurePositions[measureIndex];
+  if (!measure) return null;
+
+  const localQuant = quant % quantsPerMeasure;
+  const proportion = localQuant / quantsPerMeasure;
+  return measure.x + proportion * measure.width;
+}
+
+/**
+ * Find nearest quant position to an X coordinate.
+ */
+export function xToNearestQuant(
+  x: number,
+  validQuants: Set<number>,
+  quantToXFn: (quant: number) => number | null,
+  snapDistance = 24
+): number | null {
+  let nearest: number | null = null;
+  let nearestDist = Infinity;
+
+  for (const quant of validQuants) {
+    const qx = quantToXFn(quant);
+    if (qx === null) continue;
+
+    const dist = Math.abs(x - qx);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearest = quant;
+    }
+  }
+
+  return nearestDist <= snapDistance ? nearest : null;
+}
+
+/**
+ * Transform client (screen) coordinates to SVG local coordinates.
+ * Uses CTM for accurate handling of nested transforms.
+ */
+export function clientToSvg(
+  clientX: number,
+  clientY: number,
+  element: SVGElement
+): Point {
+  const svg = element.ownerSVGElement ?? (element as SVGSVGElement);
+  const parent = element.parentElement as SVGGraphicsElement | null;
+  const ctm = parent?.getScreenCTM() ?? svg?.getScreenCTM();
+
+  if (!svg || !ctm) {
+    // Fallback for detached elements
+    const rect = element.getBoundingClientRect();
+    return { x: clientX - rect.left, y: clientY - rect.top };
+  }
+
+  const pt = svg.createSVGPoint();
+  pt.x = clientX;
+  pt.y = clientY;
+  const transformed = pt.matrixTransform(ctm.inverse());
+  return { x: transformed.x, y: transformed.y };
+}

--- a/src/engines/layout/coordinateUtils.ts
+++ b/src/engines/layout/coordinateUtils.ts
@@ -82,11 +82,7 @@ export function xToNearestQuant(
  * Transform client (screen) coordinates to SVG local coordinates.
  * Uses CTM for accurate handling of nested transforms.
  */
-export function clientToSvg(
-  clientX: number,
-  clientY: number,
-  element: SVGElement
-): Point {
+export function clientToSvg(clientX: number, clientY: number, element: SVGElement): Point {
   const svg = element.ownerSVGElement ?? (element as SVGSVGElement);
   const parent = element.parentElement as SVGGraphicsElement | null;
   const ctm = parent?.getScreenCTM() ?? svg?.getScreenCTM();

--- a/src/engines/layout/coordinateUtils.ts
+++ b/src/engines/layout/coordinateUtils.ts
@@ -2,7 +2,6 @@
  * coordinateUtils.ts
  *
  * Shared coordinate transformation utilities for score layout.
- * All X position logic flows through these functions.
  *
  * @see Issue #204
  */
@@ -22,6 +21,10 @@ export interface MeasurePosition {
 /**
  * Convert quant to X coordinate.
  * Two-stage lookup: exact match from map, then interpolation fallback.
+ *
+ * @deprecated Use `layout.getX({ measure, quant })` instead.
+ * This function uses global quants which don't support system breaks.
+ * @see ADR-016: Measure-Relative X Positioning
  */
 export function quantToX(
   quant: number,
@@ -47,6 +50,10 @@ export function quantToX(
 
 /**
  * Find nearest quant position to an X coordinate.
+ *
+ * @deprecated Use measure-aware position lookup instead.
+ * This function uses global quants which don't support system breaks.
+ * @see ChordTrack.tsx xToNearestPosition for the new pattern.
  */
 export function xToNearestQuant(
   x: number,

--- a/src/engines/layout/index.ts
+++ b/src/engines/layout/index.ts
@@ -4,3 +4,4 @@ export * from './beaming';
 export * from './measure';
 export * from './tuplets';
 export * from './system';
+export * from './coordinateUtils';

--- a/src/engines/layout/measure.ts
+++ b/src/engines/layout/measure.ts
@@ -19,7 +19,7 @@ import { getTupletGroup } from './tuplets';
 const HIT_RADIUS = LAYOUT.HIT_ZONE_RADIUS;
 
 /** Padding added before noteheads when accidentals are present */
-const ACCIDENTAL_PADDING = NOTE_SPACING_BASE_UNIT * 0.8;
+const ACCIDENTAL_PADDING = LAYOUT.ACCIDENTAL_PADDING;
 
 /** Minimum width factors for short-duration notes relative to NOTE_SPACING_BASE_UNIT */
 // const MIN_WIDTH_FACTORS = LAYOUT.MIN_WIDTH_FACTORS;

--- a/src/engines/layout/positioning.ts
+++ b/src/engines/layout/positioning.ts
@@ -6,15 +6,6 @@ import { getStaffPitch, STAFF_LETTERS } from '@/services/MusicService';
 
 // ========== HEADER LAYOUT (SSOT) ==========
 
-// Layout constants - single source of truth
-const HEADER_LAYOUT_CONSTANTS = {
-  KEY_SIG_START_X: 45,
-  KEY_SIG_ACCIDENTAL_WIDTH: 10,
-  KEY_SIG_PADDING: 10,
-  TIME_SIG_WIDTH: 30,
-  TIME_SIG_PADDING: 20,
-};
-
 /**
  * Calculates header layout positions based on key signature.
  * This is the SINGLE SOURCE OF TRUTH for header layout calculations.
@@ -23,27 +14,25 @@ const HEADER_LAYOUT_CONSTANTS = {
  */
 export const calculateHeaderLayout = (keySignature: string): HeaderLayout => {
   const {
-    KEY_SIG_START_X,
-    KEY_SIG_ACCIDENTAL_WIDTH,
-    KEY_SIG_PADDING,
-    TIME_SIG_WIDTH,
-    TIME_SIG_PADDING,
-  } = HEADER_LAYOUT_CONSTANTS;
+    keySigStartX,
+    keySigAccidentalWidth,
+    keySigPadding,
+    timeSigWidth,
+    timeSigPadding,
+  } = CONFIG.header;
 
   const keySigCount = KEY_SIGNATURES[keySignature]?.count || 0;
-  const keySigVisualWidth = keySigCount > 0 ? keySigCount * KEY_SIG_ACCIDENTAL_WIDTH + 10 : 0;
-  const timeSigStartX = KEY_SIG_START_X + keySigVisualWidth + KEY_SIG_PADDING;
-  const startOfMeasures = timeSigStartX + TIME_SIG_WIDTH + TIME_SIG_PADDING;
+  const keySigVisualWidth = keySigCount > 0 ? keySigCount * keySigAccidentalWidth + 10 : 0;
+  const timeSigStartXPos = keySigStartX + keySigVisualWidth + keySigPadding;
+  const startOfMeasures = timeSigStartXPos + timeSigWidth + timeSigPadding;
 
   return {
-    keySigStartX: KEY_SIG_START_X,
+    keySigStartX,
     keySigVisualWidth,
-    timeSigStartX,
+    timeSigStartX: timeSigStartXPos,
     startOfMeasures,
   };
 };
-
-export const HEADER_CONSTANTS = HEADER_LAYOUT_CONSTANTS;
 
 // ========== TREBLE CLEF PITCHES (C3 to G6) ==========
 // Offset is relative to CONFIG.baseY

--- a/src/engines/layout/positioning.ts
+++ b/src/engines/layout/positioning.ts
@@ -13,13 +13,8 @@ import { getStaffPitch, STAFF_LETTERS } from '@/services/MusicService';
  * @returns HeaderLayout object with all calculated positions
  */
 export const calculateHeaderLayout = (keySignature: string): HeaderLayout => {
-  const {
-    keySigStartX,
-    keySigAccidentalWidth,
-    keySigPadding,
-    timeSigWidth,
-    timeSigPadding,
-  } = CONFIG.header;
+  const { keySigStartX, keySigAccidentalWidth, keySigPadding, timeSigWidth, timeSigPadding } =
+    CONFIG.header;
 
   const keySigCount = KEY_SIGNATURES[keySignature]?.count || 0;
   const keySigVisualWidth = keySigCount > 0 ? keySigCount * keySigAccidentalWidth + 10 : 0;

--- a/src/engines/layout/scoreLayout.ts
+++ b/src/engines/layout/scoreLayout.ts
@@ -20,7 +20,14 @@ import {
   getNoteWidth,
 } from '@/engines/layout';
 import { calculateTupletBrackets } from '@/engines/layout/tuplets';
-import { ScoreLayout, StaffLayout, MeasureLayoutV2, EventLayout, NoteLayout, YBounds } from './types';
+import {
+  ScoreLayout,
+  StaffLayout,
+  MeasureLayoutV2,
+  EventLayout,
+  NoteLayout,
+  YBounds,
+} from './types';
 
 // --- Phase 1: Synchronization Helper ---
 
@@ -320,7 +327,10 @@ export const calculateScoreLayout = (score: Score): ScoreLayout => {
     // Calculate relative X within the measure based on quant proportion
     const proportion = quant / quantsPerMeasure;
     // Use measure width minus padding for content area
-    return CONFIG.measurePaddingLeft + proportion * (measureLayout.width - CONFIG.measurePaddingLeft - CONFIG.measurePaddingRight);
+    return (
+      CONFIG.measurePaddingLeft +
+      proportion * (measureLayout.width - CONFIG.measurePaddingLeft - CONFIG.measurePaddingRight)
+    );
   };
 
   // Combine into callable with measureOrigin property

--- a/src/engines/layout/scoreLayout.ts
+++ b/src/engines/layout/scoreLayout.ts
@@ -9,6 +9,8 @@
  */
 import { Score, Staff, ScoreEvent } from '@/types';
 import { CONFIG } from '@/config';
+import { TIME_SIGNATURES } from '@/constants';
+import { getNoteDuration } from '@/utils/core';
 import {
   calculateHeaderLayout,
   calculateMeasureLayout,
@@ -16,9 +18,11 @@ import {
   calculateBeamingGroups,
   calculateSystemLayout,
   getNoteWidth,
+  quantToX,
+  MeasurePosition,
 } from '@/engines/layout';
 import { calculateTupletBrackets } from '@/engines/layout/tuplets';
-import { ScoreLayout, StaffLayout, MeasureLayoutV2, EventLayout, NoteLayout } from './types';
+import { ScoreLayout, StaffLayout, MeasureLayoutV2, EventLayout, NoteLayout, YBounds } from './types';
 
 // --- Phase 1: Synchronization Helper ---
 
@@ -160,12 +164,27 @@ const processEventLayout = (
  * This is the SINGLE SOURCE OF TRUTH for where everything is on the canvas.
  *
  * @param score - The score data
- * @returns ScoreLayout object containing full position maps
+ * @returns ScoreLayout object containing full position maps and getX function
  */
 export const calculateScoreLayout = (score: Score): ScoreLayout => {
-  const layout: ScoreLayout = { staves: [], notes: {}, events: {} };
+  // Default getX for empty scores - returns 0 for any quant
+  const emptyGetX = (): number => 0;
 
-  if (!score.staves || score.staves.length === 0) return layout;
+  // Default getY for empty scores
+  const emptyGetY: ScoreLayout['getY'] = {
+    content: { top: 0, bottom: 0 },
+    system: () => null,
+    staff: () => null,
+    notes: () => ({ top: 0, bottom: 0 }),
+    pitch: () => null,
+  };
+
+  if (!score.staves || score.staves.length === 0) {
+    return { staves: [], notes: {}, events: {}, getX: emptyGetX, getY: emptyGetY };
+  }
+
+  // Partial layout that we'll populate
+  const layout: Omit<ScoreLayout, 'getX' | 'getY'> = { staves: [], notes: {}, events: {} };
 
   const activeStaff = score.staves[0];
   const headerLayout = calculateHeaderLayout(score.keySignature || activeStaff.keySignature || 'C');
@@ -236,5 +255,142 @@ export const calculateScoreLayout = (score: Score): ScoreLayout => {
     layout.staves.push(staffLayout);
   });
 
-  return layout;
+  // --- Build getX function ---
+  const timeSignature = score.timeSignature || '4/4';
+  const quantsPerMeasure = TIME_SIGNATURES[timeSignature] || TIME_SIGNATURES['4/4'];
+
+  // Build quant→X map from note positions
+  const quantToXMap = new Map<number, number>();
+  Object.values(layout.notes).forEach((noteLayout) => {
+    const measure = score.staves[noteLayout.staffIndex]?.measures[noteLayout.measureIndex];
+    if (!measure) return;
+
+    // Calculate global quant for this note
+    let localQuant = 0;
+    for (const event of measure.events) {
+      if (event.id === noteLayout.eventId) {
+        const globalQuant = noteLayout.measureIndex * quantsPerMeasure + localQuant;
+        // Only set if not already set (use first note's X at each quant)
+        if (!quantToXMap.has(globalQuant)) {
+          quantToXMap.set(globalQuant, noteLayout.x);
+        }
+        break;
+      }
+      localQuant += getNoteDuration(event.duration, event.dotted, event.tuplet);
+    }
+  });
+
+  // Build measure positions for interpolation fallback
+  const measurePositions: MeasurePosition[] =
+    layout.staves[0]?.measures.map((m) => ({ x: m.x, width: m.width })) ?? [];
+
+  // Pre-bind the lookup function
+  const getX = (quant: number): number =>
+    quantToX(quant, quantToXMap, measurePositions, quantsPerMeasure) ?? 0;
+
+  // --- Build getY object ---
+
+  // Staff height is 5 lines = 4 gaps
+  const staffHeight = CONFIG.lineHeight * 4;
+
+  // Content region bounds
+  const lastStaffLayout = layout.staves[layout.staves.length - 1];
+  const contentTop = CONFIG.baseY;
+  const contentBottom = lastStaffLayout
+    ? lastStaffLayout.y + staffHeight
+    : CONFIG.baseY + staffHeight;
+
+  // Memoized system bounds (currently single-system)
+  const systemBoundsCache = new Map<number, YBounds | null>();
+  const system = (index: number): YBounds | null => {
+    if (systemBoundsCache.has(index)) return systemBoundsCache.get(index)!;
+
+    // Currently single-system; returns null for index > 0
+    if (index !== 0 || layout.staves.length === 0) {
+      systemBoundsCache.set(index, null);
+      return null;
+    }
+
+    const bounds: YBounds = { top: contentTop, bottom: contentBottom };
+    systemBoundsCache.set(index, bounds);
+    return bounds;
+  };
+
+  // Memoized staff bounds
+  const staffBoundsCache = new Map<number, YBounds | null>();
+  const staff = (index: number): YBounds | null => {
+    if (staffBoundsCache.has(index)) return staffBoundsCache.get(index)!;
+
+    const staffLayout = layout.staves[index];
+    if (!staffLayout) {
+      staffBoundsCache.set(index, null);
+      return null;
+    }
+
+    const bounds: YBounds = { top: staffLayout.y, bottom: staffLayout.y + staffHeight };
+    staffBoundsCache.set(index, bounds);
+    return bounds;
+  };
+
+  // Note extent (system-wide) - computed once
+  const allNoteYs = Object.values(layout.notes).map((n) => n.y);
+  const defaultBounds = staff(0) ?? { top: CONFIG.baseY, bottom: CONFIG.baseY + staffHeight };
+  const systemNoteBounds: YBounds =
+    allNoteYs.length > 0
+      ? { top: Math.min(...allNoteYs), bottom: Math.max(...allNoteYs) }
+      : defaultBounds;
+
+  // Per-quant note extent maps (built once)
+  const noteTopByQuant = new Map<number, number>();
+  const noteBottomByQuant = new Map<number, number>();
+
+  Object.values(layout.notes).forEach((noteLayout) => {
+    const measure = score.staves[noteLayout.staffIndex]?.measures[noteLayout.measureIndex];
+    if (!measure) return;
+
+    // Calculate global quant for this note (reuse logic from getX)
+    let localQuant = 0;
+    for (const event of measure.events) {
+      if (event.id === noteLayout.eventId) {
+        const globalQuant = noteLayout.measureIndex * quantsPerMeasure + localQuant;
+
+        const currentTop = noteTopByQuant.get(globalQuant) ?? Infinity;
+        if (noteLayout.y < currentTop) noteTopByQuant.set(globalQuant, noteLayout.y);
+
+        const currentBottom = noteBottomByQuant.get(globalQuant) ?? -Infinity;
+        if (noteLayout.y > currentBottom) noteBottomByQuant.set(globalQuant, noteLayout.y);
+        break;
+      }
+      localQuant += getNoteDuration(event.duration, event.dotted, event.tuplet);
+    }
+  });
+
+  const notes = (quant?: number): YBounds => {
+    if (quant === undefined) {
+      return systemNoteBounds;
+    }
+    return {
+      top: noteTopByQuant.get(quant) ?? systemNoteBounds.top,
+      bottom: noteBottomByQuant.get(quant) ?? systemNoteBounds.bottom,
+    };
+  };
+
+  // Pitch positioning (clef-aware)
+  const pitch = (p: string, staffIndex: number): number | null => {
+    const staffLayout = layout.staves[staffIndex];
+    if (!staffLayout) return null;
+
+    const clef = score.staves[staffIndex]?.clef ?? (staffIndex === 0 ? 'treble' : 'bass');
+    return staffLayout.y + getOffsetForPitch(p, clef);
+  };
+
+  const getY: ScoreLayout['getY'] = {
+    content: { top: contentTop, bottom: contentBottom },
+    system,
+    staff,
+    notes,
+    pitch,
+  };
+
+  return { ...layout, getX, getY };
 };

--- a/src/engines/layout/system.ts
+++ b/src/engines/layout/system.ts
@@ -14,7 +14,7 @@ import { calculateChordLayout } from './positioning';
 // --- CONSTANTS ---
 
 /** Padding added before noteheads when accidentals are present */
-const ACCIDENTAL_PADDING = NOTE_SPACING_BASE_UNIT * 0.8;
+const ACCIDENTAL_PADDING = LAYOUT.ACCIDENTAL_PADDING;
 
 /** Minimum width factors for short-duration notes */
 const MIN_WIDTH_FACTORS = LAYOUT.MIN_WIDTH_FACTORS;

--- a/src/engines/layout/types.ts
+++ b/src/engines/layout/types.ts
@@ -77,6 +77,15 @@ export interface HeaderLayout {
 
 // ========== SINGLE SOURCE OF TRUTH LAYOUT TYPES ==========
 
+/**
+ * Vertical bounds for layout elements.
+ * Used by getY accessors to return top/bottom positions.
+ */
+export interface YBounds {
+  top: number;
+  bottom: number;
+}
+
 export interface NoteLayout {
   x: number;
   y: number;
@@ -120,4 +129,37 @@ export interface ScoreLayout {
   notes: Record<string, NoteLayout>;
   // Key format: `${staffIndex}-${measureIndex}-${eventId}`
   events: Record<string, EventLayout>;
+
+  /**
+   * Get X coordinate for any quant position.
+   * Single entry point for ALL positioned elements (chords, cursor, lyrics, dynamics).
+   * Handles exact match lookup and interpolation fallback.
+   */
+  getX: (quant: number) => number;
+
+  /**
+   * Get Y coordinates for vertical positioning.
+   * Forward-flow design: positions derive from elements above.
+   * @see docs/migration/y-positioning-spec.md
+   */
+  getY: {
+    /** Content region bounds (contains all systems) */
+    content: YBounds;
+
+    /** System bounds. Returns null for invalid index. Currently only system(0) is valid. */
+    system: (index: number) => YBounds | null;
+
+    /** Staff bounds. Returns null for invalid index. */
+    staff: (index: number) => YBounds | null;
+
+    /**
+     * Note extent for collision avoidance.
+     * - No arg: returns system-wide extent (memoized)
+     * - With quant: returns extent at that position, falls back to system-wide
+     */
+    notes: (quant?: number) => YBounds;
+
+    /** Pitch Y position (clef-aware). Returns null for invalid staff index. */
+    pitch: (pitch: string, staffIndex: number) => number | null;
+  };
 }

--- a/src/engines/layout/types.ts
+++ b/src/engines/layout/types.ts
@@ -131,11 +131,23 @@ export interface ScoreLayout {
   events: Record<string, EventLayout>;
 
   /**
-   * Get X coordinate for any quant position.
+   * Get X coordinate for any quant position (measure-relative).
    * Single entry point for ALL positioned elements (chords, cursor, lyrics, dynamics).
-   * Handles exact match lookup and interpolation fallback.
+   *
+   * Usage:
+   * ```typescript
+   * <g transform={`translate(${layout.getX.measureOrigin({ measure }) ?? 0}, 0)`}>
+   *   <Element x={layout.getX({ measure, quant }) ?? 0} />
+   * </g>
+   * ```
    */
-  getX: (quant: number) => number;
+  getX: {
+    /** X position within a measure (measure-relative) */
+    (params: { measure: number; quant: number }): number | null;
+
+    /** Measure's origin X (for SVG transforms) */
+    measureOrigin: (params: { measure: number }) => number | null;
+  };
 
   /**
    * Get Y coordinates for vertical positioning.

--- a/src/engines/layout/types.ts
+++ b/src/engines/layout/types.ts
@@ -87,7 +87,8 @@ export interface YBounds {
 }
 
 export interface NoteLayout {
-  x: number;
+  /** X position relative to measure origin */
+  localX: number;
   y: number;
   noteId: string;
   eventId: string;
@@ -98,7 +99,8 @@ export interface NoteLayout {
 }
 
 export interface EventLayout {
-  x: number;
+  /** X position relative to measure origin */
+  localX: number;
   y: number; // Base Y for the staff
   width: number;
   notes: Record<string, NoteLayout>; // noteId -> layout

--- a/src/hooks/api/chords.ts
+++ b/src/hooks/api/chords.ts
@@ -411,7 +411,12 @@ export const createChordMethods = (
           status: 'info',
           method: 'getSelectedChord',
           message: `Selected chord: ${chord.symbol}`,
-          details: { chordId: chord.id, symbol: chord.symbol, measure: chord.measure, quant: chord.quant },
+          details: {
+            chordId: chord.id,
+            symbol: chord.symbol,
+            measure: chord.measure,
+            quant: chord.quant,
+          },
         });
       } else {
         setResult({
@@ -484,7 +489,12 @@ export const createChordMethods = (
         status: 'info',
         method: 'selectNextChord',
         message: `Selected next chord: ${nextChord.symbol}`,
-        details: { chordId: nextChord.id, symbol: nextChord.symbol, measure: nextChord.measure, quant: nextChord.quant },
+        details: {
+          chordId: nextChord.id,
+          symbol: nextChord.symbol,
+          measure: nextChord.measure,
+          quant: nextChord.quant,
+        },
       });
 
       return this;
@@ -534,7 +544,12 @@ export const createChordMethods = (
         status: 'info',
         method: 'selectPrevChord',
         message: `Selected previous chord: ${prevChord.symbol}`,
-        details: { chordId: prevChord.id, symbol: prevChord.symbol, measure: prevChord.measure, quant: prevChord.quant },
+        details: {
+          chordId: prevChord.id,
+          symbol: prevChord.symbol,
+          measure: prevChord.measure,
+          quant: prevChord.quant,
+        },
       });
 
       return this;
@@ -567,7 +582,12 @@ export const createChordMethods = (
         status: 'info',
         method: 'selectFirstChord',
         message: `Selected first chord: ${firstChord.symbol}`,
-        details: { chordId: firstChord.id, symbol: firstChord.symbol, measure: firstChord.measure, quant: firstChord.quant },
+        details: {
+          chordId: firstChord.id,
+          symbol: firstChord.symbol,
+          measure: firstChord.measure,
+          quant: firstChord.quant,
+        },
       });
 
       return this;
@@ -600,7 +620,12 @@ export const createChordMethods = (
         status: 'info',
         method: 'selectLastChord',
         message: `Selected last chord: ${lastChord.symbol}`,
-        details: { chordId: lastChord.id, symbol: lastChord.symbol, measure: lastChord.measure, quant: lastChord.quant },
+        details: {
+          chordId: lastChord.id,
+          symbol: lastChord.symbol,
+          measure: lastChord.measure,
+          quant: lastChord.quant,
+        },
       });
 
       return this;
@@ -779,7 +804,12 @@ export const createChordMethods = (
         status: 'info',
         method: 'deleteSelectedChord',
         message: `Deleted chord ${chord.symbol}`,
-        details: { deletedChordId: chord.id, symbol: chord.symbol, measure: chord.measure, quant: chord.quant },
+        details: {
+          deletedChordId: chord.id,
+          symbol: chord.symbol,
+          measure: chord.measure,
+          quant: chord.quant,
+        },
       });
 
       return this;

--- a/src/hooks/api/chords.ts
+++ b/src/hooks/api/chords.ts
@@ -282,23 +282,19 @@ export const createChordMethods = (
 
     getValidChordPositions() {
       const validPositions = getValidChordQuants(getScore());
-      // Convert Map<measure, Set<quant>> to array of { measure, quant }
-      const positions: ChordPosition[] = [];
-      for (const [measure, quants] of validPositions) {
-        for (const quant of quants) {
-          positions.push({ measure, quant });
-        }
+      // Count total positions for logging
+      let count = 0;
+      for (const quants of validPositions.values()) {
+        count += quants.size;
       }
-      // Sort by measure, then quant
-      positions.sort((a, b) => a.measure - b.measure || a.quant - b.quant);
       setResult({
         ok: true,
         status: 'info',
         method: 'getValidChordPositions',
-        message: `Found ${positions.length} valid chord position(s)`,
-        details: { count: positions.length },
+        message: `Found ${count} valid chord position(s) in ${validPositions.size} measure(s)`,
+        details: { count, measureCount: validPositions.size },
       });
-      return positions;
+      return validPositions;
     },
 
     // ========================================================================

--- a/src/hooks/layout/useCursorLayout.ts
+++ b/src/hooks/layout/useCursorLayout.ts
@@ -69,8 +69,7 @@ export const useCursorLayout = (
       return { measure: null, x: null, width: 0 };
     }
 
-    // Use first measure for base X (they are all aligned)
-    const baseMeasureX = relevantMeasures[0].x;
+    // Use first measure for base width (all measures at same quant are aligned)
     const baseMeasureWidth = relevantMeasures[0].width;
 
     // Build unified quant -> x map

--- a/src/hooks/layout/useCursorLayout.ts
+++ b/src/hooks/layout/useCursorLayout.ts
@@ -23,6 +23,9 @@ interface PlaybackPosition {
 }
 
 interface CursorLayout {
+  /** Measure index for cursor position */
+  measure: number | null;
+  /** X position within the measure (measure-relative) */
   x: number | null;
   width: number;
   isGrandStaff: boolean;
@@ -48,12 +51,12 @@ export const useCursorLayout = (
   const cursor = useMemo(() => {
     // No layout - no cursor
     if (layout.staves.length === 0) {
-      return { x: null, width: 0 };
+      return { measure: null, x: null, width: 0 };
     }
 
     const { measureIndex, quant } = playbackPosition;
     if (measureIndex === null || quant === null) {
-      return { x: null, width: 0 };
+      return { measure: null, x: null, width: 0 };
     }
 
     // Aggregate events from ALL staves to build unified system grid
@@ -63,7 +66,7 @@ export const useCursorLayout = (
       .filter(Boolean);
 
     if (relevantMeasures.length === 0) {
-      return { x: null, width: 0 };
+      return { measure: null, x: null, width: 0 };
     }
 
     // Use first measure for base X (they are all aligned)
@@ -99,12 +102,14 @@ export const useCursorLayout = (
     const quantPosition = getQuantPositionFromMap(quantToX, quant, baseMeasureWidth, isPlaying);
 
     return {
-      x: baseMeasureX + quantPosition.x,
+      measure: measureIndex,
+      x: quantPosition.x, // measure-relative X
       width: quantPosition.width,
     };
   }, [layout.staves, playbackPosition, isPlaying]);
 
   return {
+    measure: cursor.measure,
     x: cursor.x,
     width: cursor.width,
     isGrandStaff,

--- a/src/services/chord/index.ts
+++ b/src/services/chord/index.ts
@@ -63,4 +63,9 @@ export { getChordVoicing } from './ChordVoicing';
 export { getAccessibleChordName } from './ChordAccessibility';
 
 // Quants
-export { getValidChordQuants, findOrphanedChords, removeOrphanedChords } from './ChordQuants';
+export {
+  getValidChordQuants,
+  isValidChordPosition,
+  findOrphanedChords,
+  removeOrphanedChords,
+} from './ChordQuants';

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,13 +58,16 @@ export interface Staff {
 
 /**
  * Represents a chord symbol in the chord track.
- * Anchored to a global quant position.
+ * Anchored to a measure-local position for robust measure operations.
  */
 export interface ChordSymbol {
   /** Unique identifier (generated via chordId() from utils/id.ts) */
   id: string;
 
-  /** Global quant position (measureIndex * quantsPerMeasure + localQuant) */
+  /** Measure index (0-based) */
+  measure: number;
+
+  /** Local quant position within the measure (0 = start of measure) */
   quant: number;
 
   /** Canonical chord symbol (letter-name notation, e.g., 'Cmaj7', 'Am', 'G7') */

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,8 +171,8 @@ export const getActiveStaff = (score: Score, staffIndex: number = 0): Staff => {
  * Old format: { id, quant, symbol } where quant is global
  * New format: { id, measure, quant, symbol } where quant is local to measure
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Accepts unknown chord formats
 const migrateChordTrack = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Accepts unknown chord formats during migration
   chordTrack: any[] | undefined,
   timeSignature: string
 ): ChordSymbol[] | undefined => {

--- a/src/utils/chord/queries.ts
+++ b/src/utils/chord/queries.ts
@@ -9,6 +9,12 @@
 
 import type { ChordSymbol } from '@/types';
 
+/** Position for chord lookup */
+export interface ChordPosition {
+  measure: number;
+  quant: number;
+}
+
 /**
  * Find a chord by ID in the chord track.
  *
@@ -25,18 +31,35 @@ export const findChordById = (
 };
 
 /**
- * Find a chord at a specific quant position.
+ * Find a chord at a specific position.
  *
  * @param chordTrack - The chord track to search
- * @param quant - Quant position to search at
+ * @param position - Measure-local position to search at
  * @returns The chord if found, null otherwise
  */
-export const findChordAtQuant = (
+export const findChordAt = (
   chordTrack: ChordSymbol[] | undefined,
-  quant: number
+  position: ChordPosition
 ): ChordSymbol | null => {
   if (!chordTrack) return null;
-  return chordTrack.find((c) => c.quant === quant) ?? null;
+  return (
+    chordTrack.find((c) => c.measure === position.measure && c.quant === position.quant) ?? null
+  );
+};
+
+/**
+ * Find all chords in a specific measure.
+ *
+ * @param chordTrack - The chord track to search
+ * @param measureIndex - Measure index to search
+ * @returns Array of chords in the measure (may be empty)
+ */
+export const findChordsInMeasure = (
+  chordTrack: ChordSymbol[] | undefined,
+  measureIndex: number
+): ChordSymbol[] => {
+  if (!chordTrack) return [];
+  return chordTrack.filter((c) => c.measure === measureIndex);
 };
 
 /**

--- a/src/utils/navigation/vertical.ts
+++ b/src/utils/navigation/vertical.ts
@@ -375,11 +375,10 @@ export const calculateVerticalNavigation = (
       sortedNotes[sortedNotes.length - 1]?.id === selection.noteId;
 
     if (isAtTopNote) {
-      // Calculate global quant for current position
-      const globalQuant = measureIndex * currentQuantsPerMeasure + currentQuantStart;
-
       // Check if there's a chord at this position
-      const chordAtQuant = score.chordTrack.find((c) => c.quant === globalQuant);
+      const chordAtQuant = score.chordTrack.find(
+        (c) => c.measure === measureIndex && c.quant === currentQuantStart
+      );
       if (chordAtQuant) {
         return {
           selection: {
@@ -475,11 +474,10 @@ export const calculateVerticalNavigation = (
       sortedNotes.length <= 1 || !selection.noteId || sortedNotes[0]?.id === selection.noteId;
 
     if (isAtBottomNote) {
-      // Calculate global quant for current position
-      const globalQuant = measureIndex * currentQuantsPerMeasure + currentQuantStart;
-
       // Check if there's a chord at this position
-      const chordAtQuant = score.chordTrack.find((c) => c.quant === globalQuant);
+      const chordAtQuant = score.chordTrack.find(
+        (c) => c.measure === measureIndex && c.quant === currentQuantStart
+      );
       if (chordAtQuant) {
         return {
           selection: {


### PR DESCRIPTION
## Summary

Complete migration to measure-relative X coordinates to prepare for system breaks (multi-line rendering).

- **ScoreLayout API**: `getX({ measure, quant })` returns measure-relative X; `getX.measureOrigin({ measure })` returns absolute origin
- **ChordSymbol Data Model**: Now uses `{ measure, quant }` instead of global quant with auto-migration for old scores
- **Layout Types**: `NoteLayout.x` and `EventLayout.x` renamed to `localX` (measure-relative)
- **Cursor & Hit Detection**: Updated `useCursorLayout`, `ScoreCanvas`, and `useDragToSelect` to use new coordinate system
- **Deprecations**: `quantToX()` and `xToNearestQuant()` deprecated in favor of measure-aware lookups
- **Documentation**: ADR-016 and updated LAYOUT_ENGINE.md

## Test plan

- [x] All 1209 tests pass
- [x] Lint: 0 errors, 0 warnings
- [x] TypeScript: 0 errors
- [x] Formatting: All files formatted
- [x] Manual verification: chords, cursor, selection work correctly

## Related

- Closes #204
- Spec: [measure-relative-x-spec.md](docs/migration/measure-relative-x-spec.md)
- ADR: [016-measure-relative-x.md](docs/adr/016-measure-relative-x.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)