### PR TITLE
fix(engraving): correct alto/tenor key-signature glyph positions (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### For musicians
+- **Alto and tenor key signatures are correct now** — the sharps and flats sit on their proper lines and spaces (an alto F♯, for example, no longer lands on the C line). Treble and bass were already right. ([#233](https://github.com/joekotvas/riffscore/issues/233))
+
+### For developers
+- `KEY_SIGNATURE_OFFSETS` is now **derived** from each accidental's conventional engraving pitch via the shared clef geometry (`getClefReference`), instead of a hand-authored offset table — so key-signature glyphs and notes share one source and can't drift apart (the root cause of the alto/tenor bug). Verified by a geometry-oracle test that renders `ScoreHeader` and checks each glyph sits on its letter's line via the production `getPitchForOffset`. ([#233](https://github.com/joekotvas/riffscore/issues/233), [#235](https://github.com/joekotvas/riffscore/issues/235))
+
 ## [1.0.0-alpha.11] - 2026-06-03
 
 A foundational correctness pass focused on music theory, engraving, and export —

--- a/src/__tests__/geometry/clefKeySignature.test.tsx
+++ b/src/__tests__/geometry/clefKeySignature.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Clef key-signature accidental positions (#233) + geometry-oracle proof (#235).
+ *
+ * THE BUG: alto/tenor key-signature accidentals rendered on the WRONG staff lines
+ * (e.g. an alto F# glyph drawn on the C4 line) because KEY_SIGNATURE_OFFSETS was
+ * hand-authored against the wrong clef reference. The fix DERIVES the offsets from
+ * each accidental's conventional pitch + the shared clef geometry, so a key-sig
+ * glyph always sits on the same line/space as a note of that pitch.
+ *
+ * Two layers of proof:
+ *   1. Geometry consistency (render-free): every key-sig offset, for every clef,
+ *      lands on the line/space of the CORRECT diatonic letter — proven with the
+ *      PRODUCTION inverse getPitchForOffset (the same function note hit-testing
+ *      uses) and round-tripped through getOffsetForPitch so the key-sig table can
+ *      never drift from note positioning.
+ *   2. Geometry oracle (render): ScoreHeader's ACTUAL emitted SVG places each
+ *      accidental glyph at the offset the clef geometry predicts for that letter.
+ */
+/* eslint-disable testing-library/render-result-naming-convention */
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { KEY_SIGNATURES, KEY_SIGNATURE_OFFSETS, type KeySignatureOffsets } from '@/constants';
+import { getOffsetForPitch, getPitchForOffset } from '@/engines/layout/positioning';
+import { ACCIDENTALS } from '@/constants/SMuFL';
+import { ThemeProvider } from '@/context/ThemeContext';
+import ScoreHeader from '@/components/Canvas/ScoreHeader';
+import { glyphs, firstCodepointHex } from '../helpers/geometry';
+
+const CLEFS: Array<keyof KeySignatureOffsets> = ['treble', 'bass', 'alto', 'tenor'];
+
+// Conventional key-signature band: aboveStaff (-6) to belowStaff (+54). Anything
+// outside ~staff ± one ledger would be a wild placement.
+const MIN_OFFSET = -12;
+const MAX_OFFSET = 60;
+
+describe('#233 key-signature accidentals sit on the correct letter (all clefs)', () => {
+  for (const clef of CLEFS) {
+    for (const type of ['sharp', 'flat'] as const) {
+      it(`${clef} ${type}: each accidental is on a line/space of its OWN letter, on the note grid`, () => {
+        for (const [letter, offset] of Object.entries(KEY_SIGNATURE_OFFSETS[clef][type])) {
+          // Production inverse: which natural pitch occupies this offset in this clef?
+          const pitch = getPitchForOffset(offset, clef);
+          expect(pitch).toBeDefined();
+          // CORRECTNESS: the glyph's line must belong to its own letter (the bug put
+          // alto F# on the C line). Octave is the engraving convention.
+          expect(pitch![0]).toBe(letter);
+          // CONSISTENCY: the offset is exactly where a note of that pitch sits, so the
+          // key-sig table cannot drift from note positioning (the root cause).
+          expect(getOffsetForPitch(pitch!, clef)).toBe(offset);
+          // SANITY: within the staff band.
+          expect(offset).toBeGreaterThanOrEqual(MIN_OFFSET);
+          expect(offset).toBeLessThanOrEqual(MAX_OFFSET);
+        }
+      });
+    }
+  }
+
+  it('regression: alto & tenor F# are on an F line, NOT a C line (the original bug)', () => {
+    expect(getPitchForOffset(KEY_SIGNATURE_OFFSETS.alto.sharp.F, 'alto')![0]).toBe('F');
+    expect(getPitchForOffset(KEY_SIGNATURE_OFFSETS.tenor.sharp.F, 'tenor')![0]).toBe('F');
+  });
+});
+
+// Render a ScoreHeader to an SVG string the geometry helper can parse. baseY=0 so
+// each accidental glyph's `y` attribute IS its staff offset.
+const noop = () => {};
+const renderHeader = (clef: string, keySignature: string): string =>
+  renderToStaticMarkup(
+    <ThemeProvider>
+      <svg>
+        <ScoreHeader
+          clef={clef}
+          keySignature={keySignature}
+          timeSignature="4/4"
+          baseY={0}
+          showTimeSignature={false}
+          onClefClick={noop}
+          onKeySigClick={noop}
+          onTimeSigClick={noop}
+        />
+      </svg>
+    </ThemeProvider>
+  );
+
+describe('#235 geometry oracle: rendered key-sig glyphs land where the clef geometry predicts', () => {
+  const sharpCp = firstCodepointHex(ACCIDENTALS.sharp);
+  const flatCp = firstCodepointHex(ACCIDENTALS.flat);
+
+  // Worst-broken clefs (alto, tenor) for a 5-sharp and 5-flat key, plus treble/bass
+  // as the known-good control.
+  const cases: Array<{ clef: string; key: string; type: 'sharp' | 'flat' }> = [
+    { clef: 'alto', key: 'B', type: 'sharp' },
+    { clef: 'tenor', key: 'B', type: 'sharp' },
+    { clef: 'alto', key: 'Db', type: 'flat' },
+    { clef: 'tenor', key: 'Db', type: 'flat' },
+    { clef: 'treble', key: 'B', type: 'sharp' },
+    { clef: 'bass', key: 'Db', type: 'flat' },
+  ];
+
+  for (const { clef, key, type } of cases) {
+    it(`${clef} ${key} (${type}): every rendered glyph is on its letter's line`, () => {
+      const svg = renderHeader(clef, key);
+      const cp = type === 'sharp' ? sharpCp : flatCp;
+      const accidentals = glyphs(svg)
+        .filter((g) => g.codepoint === cp)
+        .sort((a, b) => a.x - b.x); // left-to-right = key-signature order
+
+      const expectedLetters = KEY_SIGNATURES[key].accidentals;
+      expect(accidentals).toHaveLength(expectedLetters.length);
+
+      accidentals.forEach((g, i) => {
+        const letter = expectedLetters[i];
+        // The emitted y equals the derived constant for that accidental...
+        expect(g.y).toBe(KEY_SIGNATURE_OFFSETS[clef as keyof KeySignatureOffsets][type][letter]);
+        // ...and (baseY=0) that y resolves to the correct letter's line in this clef.
+        expect(getPitchForOffset(g.y, clef)![0]).toBe(letter);
+      });
+    });
+  }
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@
 
 import { CONFIG } from './config';
 import { Key } from 'tonal';
+import { getClefReference } from './utils/clef';
 
 // =============================================================================
 // DERIVED LAYOUT VALUES (from CONFIG.lineHeight)
@@ -16,21 +17,6 @@ import { Key } from 'tonal';
 
 const SPACE = CONFIG.lineHeight; // 12px - distance between staff lines
 const HALF_SPACE = 0.5 * SPACE; // 6px
-
-// Staff positions (Y offset from baseY/top line of staff)
-const STAFF_POSITION = {
-  aboveStaff: -0.5 * SPACE,
-  line5: 0,
-  space4: 0.5 * SPACE,
-  line4: 1 * SPACE,
-  space3: 1.5 * SPACE,
-  line3: 2 * SPACE,
-  space2: 2.5 * SPACE,
-  line2: 3 * SPACE,
-  space1: 3.5 * SPACE,
-  line1: 4 * SPACE,
-  belowStaff: 4.5 * SPACE,
-};
 
 export const MIDDLE_LINE_Y = CONFIG.baseY + 24;
 
@@ -123,88 +109,87 @@ export interface KeySignatureOffsets {
   tenor: { sharp: Record<string, number>; flat: Record<string, number> };
 }
 
-export const KEY_SIGNATURE_OFFSETS: KeySignatureOffsets = {
+/**
+ * Conventional ENGRAVING OCTAVE of each key-signature accidental, per clef
+ * (sharps in order F C G D A E B; flats in order B E A D G C F). The octave is
+ * the only hand-authored datum — the staff offset is DERIVED below from the same
+ * clef-reference geometry that positions notes, so a key-signature glyph always
+ * sits on the exact line/space of a note of that pitch (no drift; see #233).
+ *
+ * Treble, bass and alto follow the standard down-a-4th / up-a-5th pattern; tenor
+ * SHARPS use the traditional lower-octave (ascending) exception so they fit on
+ * the staff. (Verified against the rule and against getOffsetForPitch in
+ * clefKeySignature.test.)
+ */
+const KEY_SIG_PITCHES: Record<
+  keyof KeySignatureOffsets,
+  { sharp: Record<string, string>; flat: Record<string, string> }
+> = {
   treble: {
-    sharp: {
-      F: STAFF_POSITION.line5,
-      C: STAFF_POSITION.space3,
-      G: STAFF_POSITION.aboveStaff,
-      D: STAFF_POSITION.line4,
-      A: STAFF_POSITION.space2,
-      E: STAFF_POSITION.space4,
-      B: STAFF_POSITION.line3,
-    },
-    flat: {
-      B: STAFF_POSITION.line3,
-      E: STAFF_POSITION.space4,
-      A: STAFF_POSITION.space2,
-      D: STAFF_POSITION.line4,
-      G: STAFF_POSITION.line2,
-      C: STAFF_POSITION.space3,
-      F: STAFF_POSITION.space1,
-    },
-  },
-  alto: {
-    sharp: {
-      F: STAFF_POSITION.line3, // C-clef center is Line 3 (Middle C)
-      C: STAFF_POSITION.space1,
-      G: STAFF_POSITION.aboveStaff, // or space 5
-      D: STAFF_POSITION.line2,
-      A: STAFF_POSITION.space4,
-      E: STAFF_POSITION.space2,
-      B: STAFF_POSITION.line4,
-    },
-    flat: {
-      B: STAFF_POSITION.line4,
-      E: STAFF_POSITION.space2,
-      A: STAFF_POSITION.space4,
-      D: STAFF_POSITION.line2,
-      G: STAFF_POSITION.aboveStaff,
-      C: STAFF_POSITION.space2,
-      F: STAFF_POSITION.line1,
-    },
-  },
-  // Tenor Clef: Line 4 = C4 (Middle C)
-  // Line 1=D3, Space1=E3, Line2=F3, Space2=G3, Line3=A3, Space3=B3, Line4=C4, Space4=D4, Line5=E4
-  tenor: {
-    sharp: {
-      F: STAFF_POSITION.space4, // F4
-      C: STAFF_POSITION.line4, // C4 is Line 4, so C#4 is on Line 4
-      G: STAFF_POSITION.aboveStaff, // G4 is above staff
-      D: STAFF_POSITION.space4, // D4
-      A: STAFF_POSITION.line3, // A3
-      E: STAFF_POSITION.line5, // E4
-      B: STAFF_POSITION.space3, // B3
-    },
-    flat: {
-      B: STAFF_POSITION.space3, // B3
-      E: STAFF_POSITION.line5, // E4
-      A: STAFF_POSITION.line3, // A3
-      D: STAFF_POSITION.space4, // D4
-      G: STAFF_POSITION.aboveStaff, // G4
-      C: STAFF_POSITION.line4, // C4
-      F: STAFF_POSITION.space2, // F3
-    },
+    sharp: { F: 'F5', C: 'C5', G: 'G5', D: 'D5', A: 'A4', E: 'E5', B: 'B4' },
+    flat: { B: 'B4', E: 'E5', A: 'A4', D: 'D5', G: 'G4', C: 'C5', F: 'F4' },
   },
   bass: {
-    sharp: {
-      F: STAFF_POSITION.line4,
-      C: STAFF_POSITION.space2,
-      G: STAFF_POSITION.space4,
-      D: STAFF_POSITION.line3,
-      A: STAFF_POSITION.line5,
-      E: STAFF_POSITION.space3,
-      B: STAFF_POSITION.aboveStaff,
-    },
-    flat: {
-      B: STAFF_POSITION.line2,
-      E: STAFF_POSITION.space3,
-      A: STAFF_POSITION.space1,
-      D: STAFF_POSITION.line3,
-      G: STAFF_POSITION.line1,
-      C: STAFF_POSITION.space2,
-      F: STAFF_POSITION.belowStaff,
-    },
+    sharp: { F: 'F3', C: 'C3', G: 'G3', D: 'D3', A: 'A3', E: 'E3', B: 'B3' },
+    flat: { B: 'B2', E: 'E3', A: 'A2', D: 'D3', G: 'G2', C: 'C3', F: 'F2' },
+  },
+  alto: {
+    sharp: { F: 'F4', C: 'C4', G: 'G4', D: 'D4', A: 'A3', E: 'E4', B: 'B3' },
+    flat: { B: 'B3', E: 'E4', A: 'A3', D: 'D4', G: 'G3', C: 'C4', F: 'F3' },
+  },
+  tenor: {
+    sharp: { F: 'F3', C: 'C4', G: 'G3', D: 'D4', A: 'A3', E: 'E4', B: 'B3' },
+    flat: { B: 'B3', E: 'E4', A: 'A3', D: 'D4', G: 'G3', C: 'C4', F: 'F3' },
+  },
+};
+
+// Diatonic index of a natural pitch (e.g. 'C4' -> 28), for staff-step arithmetic.
+const DIATONIC_LETTERS = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+const diatonicIndex = (pitch: string): number => {
+  const m = pitch.match(/^([A-G])(-?\d+)$/);
+  return m ? parseInt(m[2], 10) * 7 + DIATONIC_LETTERS.indexOf(m[1]) : 0;
+};
+
+/**
+ * Staff Y offset (relative to baseY) of a natural pitch in a clef. MUST match
+ * engines/layout getOffsetForPitch: `(5 - referenceLine)*SPACE - steps*HALF_SPACE`.
+ * Implemented here against the leaf module clef.ts to avoid a constants <->
+ * positioning import cycle; the equivalence is asserted in clefKeySignature.test.
+ */
+const staffOffsetForPitch = (pitch: string, clef: keyof KeySignatureOffsets): number => {
+  const { referencePitch, referenceLine } = getClefReference(clef);
+  const steps = diatonicIndex(pitch) - diatonicIndex(referencePitch);
+  return (5 - referenceLine) * SPACE - steps * HALF_SPACE;
+};
+
+const deriveOffsets = (
+  pitches: Record<string, string>,
+  clef: keyof KeySignatureOffsets
+): Record<string, number> =>
+  Object.fromEntries(
+    Object.entries(pitches).map(([letter, pitch]) => [letter, staffOffsetForPitch(pitch, clef)])
+  );
+
+/**
+ * Key-signature accidental Y offsets, DERIVED from the conventional pitches above
+ * and the shared clef geometry — so they always agree with note positioning.
+ */
+export const KEY_SIGNATURE_OFFSETS: KeySignatureOffsets = {
+  treble: {
+    sharp: deriveOffsets(KEY_SIG_PITCHES.treble.sharp, 'treble'),
+    flat: deriveOffsets(KEY_SIG_PITCHES.treble.flat, 'treble'),
+  },
+  bass: {
+    sharp: deriveOffsets(KEY_SIG_PITCHES.bass.sharp, 'bass'),
+    flat: deriveOffsets(KEY_SIG_PITCHES.bass.flat, 'bass'),
+  },
+  alto: {
+    sharp: deriveOffsets(KEY_SIG_PITCHES.alto.sharp, 'alto'),
+    flat: deriveOffsets(KEY_SIG_PITCHES.alto.flat, 'alto'),
+  },
+  tenor: {
+    sharp: deriveOffsets(KEY_SIG_PITCHES.tenor.sharp, 'tenor'),
+    flat: deriveOffsets(KEY_SIG_PITCHES.tenor.flat, 'tenor'),
   },
 };
 


### PR DESCRIPTION
Fixes #233 (and applies the #235 geometry oracle to verify it).

## For musicians
Alto and tenor **key signatures** now render correctly — sharps and flats sit on their proper lines/spaces (an alto F♯ no longer lands on the C line). Treble and bass were already correct.

## For developers
The clef-geometry rework in alpha-11 fixed note positions but left the hand-authored `KEY_SIGNATURE_OFFSETS` table untouched, so alto (13/14) and tenor (4/14) key-sig glyphs sat on the wrong lines — a dual-source inconsistency.

This derives `KEY_SIGNATURE_OFFSETS` from each accidental's **conventional engraving pitch** via the same clef reference the notes use (`getClefReference`), so the glyphs and notes share one source and cannot drift. The only hand-authored datum is the conventional octave per clef; treble/bass/alto follow the standard down-4th/up-5th pattern, tenor sharps use the documented lower-octave exception. Cycle-safe (derives through the leaf module `clef.ts`, not `positioning`).

## Verification (#235 geometry oracle)
- **Render-free consistency:** for every clef × key × accidental, `getPitchForOffset(offset, clef)` resolves to the correct *letter*, and `getOffsetForPitch(thatPitch, clef)` round-trips to the same offset — tying the table to note positioning so it can't drift again.
- **Render oracle:** renders `ScoreHeader` for the worst cases (alto/tenor, 5 sharps + 5 flats) and asserts each emitted glyph's `y` lands on its letter's line via the geometry helper + production `getPitchForOffset`.

Gate: typecheck · lint · **2,448 tests** · build, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)