### PR TITLE
Deep-QA remediation: tuplet/reflow/reserved-slot integrity + API result consistency

### DIFF
--- a/src/__tests__/ScoreAPI.entry.test.tsx
+++ b/src/__tests__/ScoreAPI.entry.test.tsx
@@ -406,6 +406,46 @@ describe('ScoreAPI Entry Methods', () => {
     });
   });
 
+  describe('deep-QA regressions (#3, #4)', () => {
+    test('#3 selectAtQuant uses tuplet footprint — selects the right event in a bar with a triplet', () => {
+      render(<RiffScore id="saq-tuplet" />);
+      const api = getAPI('saq-tuplet');
+      // [eighth-triplet C/D/E (16q total)] then a quarter F (16q) in 4/4.
+      act(() => {
+        api.select(0).addNote('C4', 'eighth').addNote('D4', 'eighth').addNote('E4', 'eighth');
+        api.select(0, 0, 0, 0).makeTuplet(3, 2);
+        api.select(0, 0, 3, 0).addNote('F4', 'quarter');
+      });
+      // The quarter starts at quant 16 (after the 16q triplet). With the old nominal-duration walk
+      // (3×8=24) selectAtQuant(0, 16) would mis-map; now it must land on the quarter (F4).
+      act(() => api.selectAtQuant(0, 16));
+      const sel = api.getSelection();
+      const ev = api.getScore().staves[0].measures[0].events.find((e) => e.id === sel.eventId);
+      expect(ev?.notes[0].pitch).toBe('F4');
+    });
+
+    test('#4 addTone onto a rest PROMOTES it to a note (no swallowed note / malformed event)', () => {
+      render(<RiffScore id="tone-on-rest" />);
+      const api = getAPI('tone-on-rest');
+      act(() => {
+        api.setInputMode('rest');
+        api.select(0).addRest('quarter'); // a rest event
+        api.select(0, 0, 0, 0);
+        api.addTone('C4'); // add a tone onto the rest
+      });
+      const ev = api.getScore().staves[0].measures[0].events[0];
+      expect(ev.isRest).toBeFalsy(); // promoted — not a rest with a hidden note
+      expect(ev.notes.some((n) => n.pitch === 'C4')).toBe(true);
+      expect(ev.notes.every((n) => n.pitch !== null)).toBe(true); // no null-pitch placeholder left
+
+      // undo restores the rest exactly
+      act(() => api.undo());
+      const restored = api.getScore().staves[0].measures[0].events[0];
+      expect(restored.isRest).toBe(true);
+      expect(restored.notes.some((n) => n.pitch === 'C4')).toBe(false);
+    });
+  });
+
   describe('tuplet input (#242): fill reserved space', () => {
     test('typing a pitch onto a reserved slot fills it at the slot rhythm', () => {
       render(<RiffScore id="tup-fill" />);

--- a/src/__tests__/ScoreAPI.entry.test.tsx
+++ b/src/__tests__/ScoreAPI.entry.test.tsx
@@ -444,6 +444,39 @@ describe('ScoreAPI Entry Methods', () => {
       expect(restored.isRest).toBe(true);
       expect(restored.notes.some((n) => n.pitch === 'C4')).toBe(false);
     });
+
+    test('unmakeTuplet precheck drops reserved slots — does not falsely reject a valid removal (Codex P2)', () => {
+      render(<RiffScore id="unmake-reserved" />);
+      const api = getAPI('unmake-reserved');
+      const etrip = (id: string, pitch: string, pos: number) => ({
+        id, duration: 'eighth', dotted: false,
+        notes: [{ id: `${id}n`, pitch }],
+        tuplet: { ratio: [3, 2] as [number, number], groupSize: 3, position: pos, baseDuration: 'eighth', id: 'T' },
+      });
+      const eighth = (id: string, pitch: string) => ({ id, duration: 'eighth', dotted: false, notes: [{ id: `${id}n`, pitch }] });
+      const reservedSlot = {
+        id: 'tr', duration: 'eighth', dotted: false, reserved: true, isRest: true,
+        tuplet: { ratio: [3, 2] as [number, number], groupSize: 3, position: 2, baseDuration: 'eighth', id: 'T' },
+        notes: [{ id: 'tr-rest', pitch: null, isRest: true, reserved: true }],
+      };
+      act(() => {
+        api.loadScore({
+          title: 'T', timeSignature: '4/4', keySignature: 'C', bpm: 120,
+          staves: [{ id: 's0', clef: 'treble', keySignature: 'C', measures: [{ id: 'm0', events: [
+            etrip('t0', 'C4', 0), etrip('t1', 'D4', 1), reservedSlot, // triplet: 2 real + 1 reserved (16q)
+            eighth('a', 'E4'), eighth('b', 'F4'), eighth('c', 'G4'),
+            eighth('d', 'A4'), eighth('e', 'B4'), eighth('f', 'C5'),  // + 6 eighths (48q) = 64q full
+          ] }] }],
+        });
+        api.select(0, 0, 0, 0); // a triplet member
+        api.unmakeTuplet();
+      });
+      // Removing leaves 2 eighths + 6 eighths = 64q (exactly full) — must SUCCEED, not falsely reject.
+      expect(api.result.ok).toBe(true);
+      const events = api.getScore().staves[0].measures[0].events;
+      expect(events.some((e) => e.tuplet)).toBe(false);
+      expect(events.some((e) => e.reserved)).toBe(false); // reserved slot collapsed
+    });
   });
 
   describe('tuplet input (#242): fill reserved space', () => {

--- a/src/__tests__/ScoreAPI.modification.test.tsx
+++ b/src/__tests__/ScoreAPI.modification.test.tsx
@@ -627,4 +627,39 @@ describe('ScoreAPI Modification & IO Methods', () => {
       expect(eventsC3.length).toBe(0); // Expect data loss
     });
   });
+
+  describe('deep-QA regressions (#14, #19, #21)', () => {
+    test('#14 deleteSelected with no selection reports a failure (consistent with NO_SELECTION)', () => {
+      render(<RiffScore id="dq-del" />);
+      const api = getAPI('dq-del');
+      act(() => api.deselectAll());
+      api.deleteSelected();
+      const r = api.result;
+      expect(r.ok).toBe(false);
+      expect(r.status).toBe('error');
+      expect(r.code).toBe('NO_SELECTION');
+    });
+
+    test('#19 setTimeSignature to the current value is a no-op that does not pollute undo', () => {
+      render(<RiffScore id="dq-ts" />);
+      const api = getAPI('dq-ts');
+      act(() => api.setTimeSignature('3/4')); // a real change
+      const canUndoAfterReal = api.getScore().timeSignature;
+      expect(canUndoAfterReal).toBe('3/4');
+      act(() => api.setTimeSignature('3/4')); // unchanged → no-op
+      // undo once should revert the ONE real change back to the default, proving the no-op didn't
+      // push a second command.
+      act(() => api.undo());
+      expect(api.getScore().timeSignature).not.toBe('3/4');
+    });
+
+    test('#21 transposeDiatonic with a null-measure selection reports a failure (no false ok)', () => {
+      render(<RiffScore id="dq-tr" />);
+      const api = getAPI('dq-tr');
+      act(() => api.deselectAll());
+      api.transposeDiatonic(1);
+      expect(api.result.ok).toBe(false);
+      expect(api.result.code).toBe('NO_SELECTION');
+    });
+  });
 });

--- a/src/__tests__/ScoreAPI.navigation.test.tsx
+++ b/src/__tests__/ScoreAPI.navigation.test.tsx
@@ -272,6 +272,24 @@ describe('Navigation - tuplet-fill ghost stepping (#6)', () => {
     act(() => api.move('right'));
     expect(api.getSelection().measureIndex).toBe(1); // with the stale-ghost bug this was 0
   });
+
+  test('#9 jump("end-measure") lands on the last REAL member, not a trailing reserved slot', () => {
+    render(<RiffScore id="nav-jump-reserved" />);
+    const api = getAPI('nav-jump-reserved');
+    act(() => {
+      api.select(0).addNote('C4', 'eighth').addNote('D4', 'eighth').addNote('E4', 'eighth');
+      api.select(0, 0, 0, 0).makeTuplet(3, 2);
+      api.select(0, 0, 1, 0).deleteSelected(); // delete middle → trailing reserved slot
+    });
+    const events = api.getScore().staves[0].measures[0].events;
+    const reservedIdx = events.findIndex((e) => e.reserved);
+    expect(reservedIdx).toBeGreaterThanOrEqual(0); // there IS a trailing reserved slot
+
+    act(() => api.jump('end-measure'));
+    const sel = api.getSelection();
+    const landed = events.find((e) => e.id === sel.eventId);
+    expect(landed?.reserved).toBeFalsy(); // landed on a real member, not the blank slot
+  });
 });
 
 describe('Navigation - Vertical (Cross-Staff)', () => {

--- a/src/__tests__/TupletCommands.test.ts
+++ b/src/__tests__/TupletCommands.test.ts
@@ -84,10 +84,11 @@ describe('Tuplet Commands', () => {
     });
 
     test('should handle quintuplet (5:4 ratio)', () => {
-      // Add one more event for quintuplet
+      // Add one more event for quintuplet — same duration as the others: a tuplet group must be
+      // uniform (the group is stamped with a single baseDuration), else it's an incoherent group.
       baseScore.staves[0].measures[0].events.push({
         id: 'e5',
-        duration: 'eighth',
+        duration: 'quarter',
         dotted: false,
         notes: [{ id: 'n5', pitch: 'G4' }],
       });

--- a/src/__tests__/commands/measureUndoDesync.test.ts
+++ b/src/__tests__/commands/measureUndoDesync.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Deep-QA regressions #8/#18: Add/DeleteMeasure undo must stay correct when a grand staff is desynced
+ * (staves with unequal measure counts), and #16: range linearization skips reserved tuplet slots.
+ */
+import { AddMeasureCommand, DeleteMeasureCommand } from '@/commands';
+import { getLinearizedNotes } from '@/utils/selection';
+import { createDefaultScore, Measure, Score, ScoreEvent } from '@/types';
+
+const m = (id: string, n: number): Measure => ({
+  id,
+  events: Array.from({ length: n }, (_, i) => ({
+    id: `${id}e${i}`,
+    duration: 'quarter',
+    dotted: false,
+    notes: [{ id: `${id}n${i}`, pitch: 'C4' }],
+  })),
+});
+
+// A grand staff where staff 1 has FEWER measures than staff 0 (desynced).
+const desynced = (): Score => {
+  const s = createDefaultScore();
+  s.staves = [
+    { ...s.staves[0], clef: 'treble', measures: [m('t0', 1), m('t1', 1), m('t2', 1)] },
+    { id: 'sb', clef: 'bass', keySignature: 'C', measures: [m('b0', 1)] },
+  ] as Score['staves'];
+  return s;
+};
+const counts = (s: Score) => s.staves.map((st) => st.measures.length);
+
+describe('#8 AddMeasureCommand.undo on a desynced grand staff', () => {
+  it('removes the added bar from every staff by its recorded id (no orphan)', () => {
+    const s = desynced();
+    const before = counts(s); // [3, 1]
+    const cmd = new AddMeasureCommand(); // append
+    const added = cmd.execute(s);
+    expect(counts(added)).toEqual([4, 2]);
+    const undone = cmd.undo(added);
+    expect(counts(undone)).toEqual(before); // [3, 1] — no orphaned bar left on either staff
+  });
+});
+
+describe('#18 DeleteMeasureCommand.undo on a desynced grand staff', () => {
+  it('restores the deleted bar to the correct staff (index-aligned)', () => {
+    const s = desynced();
+    const cmd = new DeleteMeasureCommand(0); // delete bar 0 from both staves (both have it)
+    const deleted = cmd.execute(s);
+    expect(counts(deleted)).toEqual([2, 0]);
+    const undone = cmd.undo(deleted);
+    expect(counts(undone)).toEqual([3, 1]);
+    // the restored bars went back to their own staves (ids match), not swapped
+    expect(undone.staves[0].measures[0].id).toBe('t0');
+    expect(undone.staves[1].measures[0].id).toBe('b0');
+  });
+});
+
+describe('#16 getLinearizedNotes skips reserved tuplet slots', () => {
+  it('omits reserved placeholders from the linearized note list', () => {
+    const s = createDefaultScore();
+    const reserved: ScoreEvent = {
+      id: 'r',
+      duration: 'eighth',
+      dotted: false,
+      reserved: true,
+      isRest: true,
+      tuplet: { ratio: [3, 2], groupSize: 3, position: 2, baseDuration: 'eighth', id: 'T' },
+      notes: [{ id: 'r-rest', pitch: null, isRest: true, reserved: true }],
+    };
+    const real: ScoreEvent = {
+      id: 'a',
+      duration: 'eighth',
+      dotted: false,
+      tuplet: { ratio: [3, 2], groupSize: 3, position: 0, baseDuration: 'eighth', id: 'T' },
+      notes: [{ id: 'an', pitch: 'C4' }],
+    };
+    s.staves = [{ ...s.staves[0], measures: [{ id: 'm0', events: [real, reserved] }] }];
+    const linear = getLinearizedNotes(s);
+    expect(linear.some((n) => n.eventId === 'a')).toBe(true);
+    expect(linear.some((n) => n.eventId === 'r')).toBe(false); // reserved slot excluded
+  });
+});

--- a/src/__tests__/commands/tupletGuards.test.ts
+++ b/src/__tests__/commands/tupletGuards.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Deep-QA regressions: make/unmake tuplet must honor the "no silent overflow / no incoherent group"
+ * invariants the #242 branch introduced.
+ *   #1 — RemoveTupletCommand must not silently overfill the bar.
+ *   #2 — ApplyTupletCommand must reject a non-uniform (mixed-duration) selection.
+ */
+import { ApplyTupletCommand, RemoveTupletCommand } from '@/commands';
+import { sumQuants } from '@/utils/tuplet';
+import { validateMeasure } from '@/utils/validation';
+import { getMeasureCapacity } from '@/constants';
+import { createDefaultScore, ScoreEvent, Score } from '@/types';
+
+const ev = (id: string, duration: string): ScoreEvent => ({
+  id, duration, dotted: false, notes: [{ id: `${id}n`, pitch: 'C4' }],
+});
+const scoreWith = (events: ScoreEvent[], ts: string): Score => {
+  const s = createDefaultScore();
+  s.timeSignature = ts;
+  s.staves = [{ ...s.staves[0], measures: [{ id: 'm0', events }] }];
+  return s;
+};
+const m0 = (s: Score) => s.staves[0].measures[0];
+
+describe('#1 RemoveTupletCommand never silently overfills', () => {
+  it('refuses (no-op) when restoring full durations would overflow the bar', () => {
+    const cap = getMeasureCapacity('2/4'); // 32
+    // 2/4 bar: an eighth-triplet (16q) + a quarter (16q) = 32q, exactly full.
+    let s = scoreWith([ev('a', 'eighth'), ev('b', 'eighth'), ev('c', 'eighth'), ev('q', 'quarter')], '2/4');
+    s = new ApplyTupletCommand(0, 0, 3, [3, 2]).execute(s);
+    expect(validateMeasure(m0(s), cap).valid).toBe(true);
+
+    const before = m0(s).events;
+    const after = new RemoveTupletCommand(0, 0).execute(s);
+    // Stripping the triplet would restore 3×eighth (24q) + quarter (16q) = 40q > 32 → fail closed.
+    expect(m0(after).events).toBe(before); // untouched
+    expect(validateMeasure(m0(after), cap).valid).toBe(true);
+  });
+
+  it('still removes a tuplet when there IS room', () => {
+    const cap = getMeasureCapacity('4/4'); // 64
+    let s = scoreWith([ev('a', 'eighth'), ev('b', 'eighth'), ev('c', 'eighth')], '4/4');
+    s = new ApplyTupletCommand(0, 0, 3, [3, 2]).execute(s);
+    s = new RemoveTupletCommand(0, 0).execute(s);
+    expect(m0(s).events.every((e) => !e.tuplet)).toBe(true);
+    expect(validateMeasure(m0(s), cap).valid).toBe(true); // 3×eighth = 24q ≤ 64
+  });
+});
+
+describe('#2 ApplyTupletCommand rejects a non-uniform selection', () => {
+  it('leaves the score untouched for mixed durations (would mint an incoherent group)', () => {
+    const s = scoreWith([ev('q', 'quarter'), ev('e1', 'eighth'), ev('e2', 'eighth')], '4/4');
+    const after = new ApplyTupletCommand(0, 0, 3, [3, 2]).execute(s);
+    expect(after).toBe(s); // no-op
+    expect(m0(after).events.some((e) => e.tuplet)).toBe(false);
+  });
+
+  it('still applies for a uniform selection', () => {
+    const s = scoreWith([ev('a', 'eighth'), ev('b', 'eighth'), ev('c', 'eighth')], '4/4');
+    const after = new ApplyTupletCommand(0, 0, 3, [3, 2]).execute(s);
+    expect(m0(after).events.every((e) => e.tuplet?.id)).toBe(true);
+    expect(sumQuants(m0(after).events).partialTuplet).toBe(false);
+  });
+});

--- a/src/__tests__/commands/tupletGuards.test.ts
+++ b/src/__tests__/commands/tupletGuards.test.ts
@@ -36,6 +36,27 @@ describe('#1 RemoveTupletCommand never silently overfills', () => {
     expect(validateMeasure(m0(after), cap).valid).toBe(true);
   });
 
+  it('fails closed on overflow even in a PICKUP bar (pickups are validated at full capacity)', () => {
+    const cap = getMeasureCapacity('2/4'); // 32
+    const s = createDefaultScore();
+    s.timeSignature = '2/4';
+    s.staves = [
+      {
+        ...s.staves[0],
+        measures: [
+          { id: 'm0', isPickup: true, events: [ev('a', 'eighth'), ev('b', 'eighth'), ev('c', 'eighth'), ev('q', 'quarter')] },
+        ],
+      },
+    ];
+    const applied = new ApplyTupletCommand(0, 0, 3, [3, 2]).execute(s); // triplet 16q + quarter 16q = 32q (valid pickup)
+    expect(validateMeasure(applied.staves[0].measures[0], cap).valid).toBe(true);
+    const before = applied.staves[0].measures[0].events;
+    const after = new RemoveTupletCommand(0, 0).execute(applied);
+    // Restoring → 3 eighths (24) + quarter (16) = 40 > 32 → must fail closed even on a pickup.
+    expect(after.staves[0].measures[0].events).toBe(before);
+    expect(validateMeasure(after.staves[0].measures[0], cap).valid).toBe(true);
+  });
+
   it('still removes a tuplet when there IS room', () => {
     const cap = getMeasureCapacity('4/4'); // 64
     let s = scoreWith([ev('a', 'eighth'), ev('b', 'eighth'), ev('c', 'eighth')], '4/4');

--- a/src/__tests__/commands/tupletGuards.test.ts
+++ b/src/__tests__/commands/tupletGuards.test.ts
@@ -4,7 +4,7 @@
  *   #1 — RemoveTupletCommand must not silently overfill the bar.
  *   #2 — ApplyTupletCommand must reject a non-uniform (mixed-duration) selection.
  */
-import { ApplyTupletCommand, RemoveTupletCommand } from '@/commands';
+import { ApplyTupletCommand, RemoveTupletCommand, DeleteEventCommand } from '@/commands';
 import { sumQuants } from '@/utils/tuplet';
 import { validateMeasure } from '@/utils/validation';
 import { getMeasureCapacity } from '@/constants';
@@ -59,5 +59,27 @@ describe('#2 ApplyTupletCommand rejects a non-uniform selection', () => {
     const after = new ApplyTupletCommand(0, 0, 3, [3, 2]).execute(s);
     expect(m0(after).events.every((e) => e.tuplet?.id)).toBe(true);
     expect(sumQuants(m0(after).events).partialTuplet).toBe(false);
+  });
+});
+
+describe('#7 RemoveTupletCommand drops reserved slots (no orphan rest)', () => {
+  it('collapses a freed slot instead of leaving a reserved rest in plain space', () => {
+    // Build an eighth-triplet, then delete the middle member → a reserved slot remains.
+    let s = scoreWith([ev('a', 'eighth'), ev('b', 'eighth'), ev('c', 'eighth')], '4/4');
+    s = new ApplyTupletCommand(0, 0, 3, [3, 2]).execute(s);
+    s = new DeleteEventCommand(0, 'b', 0).execute(s);
+    expect(m0(s).events.some((e) => e.reserved)).toBe(true); // reserved slot present
+
+    const before = m0(s).events;
+    const removeCmd = new RemoveTupletCommand(0, 0);
+    s = removeCmd.execute(s);
+    // No tuplet metadata AND no orphaned reserved rest left behind.
+    expect(m0(s).events.some((e) => e.tuplet)).toBe(false);
+    expect(m0(s).events.some((e) => e.reserved)).toBe(false);
+    expect(m0(s).events.every((e) => !e.reserved && e.notes.every((n) => n.pitch !== null))).toBe(true);
+
+    // undo restores the prior state exactly (reserved slot back).
+    const undone = removeCmd.undo(s);
+    expect(m0(undone).events).toEqual(before);
   });
 });

--- a/src/__tests__/exporters/exportNormalize.test.ts
+++ b/src/__tests__/exporters/exportNormalize.test.ts
@@ -47,8 +47,16 @@ describe('padMeasureForExport', () => {
     expect(padMeasureForExport(measure([note('a', 'quarter')], true), 64)).toHaveLength(1);
   });
 
-  it('leaves an empty bar untouched (whole-rest handled elsewhere)', () => {
-    expect(padMeasureForExport(measure([]), 64)).toHaveLength(0);
+  it('materializes an empty (non-pickup) bar as a full-bar rest (e.g. grand-staff parity padding)', () => {
+    const padded = padMeasureForExport(measure([]), 64);
+    expect(padded.length).toBeGreaterThan(0);
+    expect(padded.every((e) => e.isRest)).toBe(true);
+    // exporters consume footprint quants — the rest(s) must fill the whole bar, not leave it empty.
+    expect(sumQuants(padded).quants).toBe(64);
+  });
+
+  it('leaves an empty pickup bar untouched (genuinely short)', () => {
+    expect(padMeasureForExport(measure([], true), 64)).toHaveLength(0);
   });
 });
 

--- a/src/__tests__/utils/reflowTuplet.test.ts
+++ b/src/__tests__/utils/reflowTuplet.test.ts
@@ -94,6 +94,22 @@ describe('reflowScore keeps tuplets atomic (#256)', () => {
     expect(Math.round(after)).toBe(Math.round(before)); // total duration conserved (no inflation)
   });
 
+  it('re-bars a note larger than the new bar without an overfull or spurious-empty bar (#5)', () => {
+    // A whole note (64q) reflowed to 3/8 (cap 24): the remainder must re-bar in bar-sized chunks,
+    // never dumping a 32q half-note fragment into a 24q bar (overfull) + an empty bar before it.
+    const cap = getMeasureCapacity('3/8'); // 24
+    const before = [{ id: 'm0', events: [{ id: 'w', duration: 'whole', dotted: false, notes: [{ id: 'wn', pitch: 'C4' }] }] }] as Measure[];
+    const out = reflowScore(before, '3/8');
+    out.forEach((m) => {
+      expect(m.events.length).toBeGreaterThan(0); // no spurious empty interior bar
+      expect(sumQuants(m.events).quants).toBeLessThanOrEqual(cap); // no overfull bar
+      expect(validateMeasure(m, cap).valid).toBe(true);
+    });
+    // total duration conserved (whole = 64q)
+    const total = out.reduce((s, m) => s + sumQuants(m.events).quants, 0);
+    expect(total).toBe(64);
+  });
+
   it('plain (non-tuplet) notes still split-and-tie across the bar line', () => {
     // 4/4 [quarter, half] → 2/4: the half straddles the bar line and splits into two tied quarters.
     const m: Measure[] = [

--- a/src/commands/AddNoteToEventCommand.ts
+++ b/src/commands/AddNoteToEventCommand.ts
@@ -5,6 +5,10 @@ import { updateEvent } from '@/utils/commandHelpers';
 export class AddNoteToEventCommand implements Command {
   public readonly type = 'ADD_NOTE_TO_EVENT';
 
+  // Set when execute() PROMOTED a rest event to a note (rather than appending a chord tone), so undo
+  // can restore the rest exactly.
+  private promotedFrom: { isRest?: boolean; reserved?: boolean; notes: Note[] } | null = null;
+
   constructor(
     private measureIndex: number,
     private eventId: string,
@@ -13,9 +17,21 @@ export class AddNoteToEventCommand implements Command {
   ) {}
 
   execute(score: Score): Score {
+    this.promotedFrom = null;
     return updateEvent(score, this.staffIndex, this.measureIndex, this.eventId, (event) => {
       // Check duplicate
       if (event.notes.some((n) => n.pitch === this.note.pitch)) return false;
+
+      // Adding the first real note to a REST promotes it to a note event — you can't stack a tone
+      // onto a rest. Appending instead would leave isRest:true with a pitched note (a malformed event
+      // the renderer/exporter treat as a rest, silently swallowing the note).
+      if (event.isRest) {
+        this.promotedFrom = { isRest: event.isRest, reserved: event.reserved, notes: event.notes };
+        event.isRest = false;
+        event.reserved = false;
+        event.notes = [this.note];
+        return true;
+      }
 
       event.notes = [...event.notes, this.note];
       return true;
@@ -24,6 +40,12 @@ export class AddNoteToEventCommand implements Command {
 
   undo(score: Score): Score {
     return updateEvent(score, this.staffIndex, this.measureIndex, this.eventId, (event) => {
+      if (this.promotedFrom) {
+        event.isRest = this.promotedFrom.isRest;
+        event.reserved = this.promotedFrom.reserved;
+        event.notes = this.promotedFrom.notes;
+        return true;
+      }
       const initialLength = event.notes.length;
       event.notes = event.notes.filter((n) => n.id !== this.note.id);
       return event.notes.length !== initialLength;

--- a/src/commands/MeasureCommands.ts
+++ b/src/commands/MeasureCommands.ts
@@ -48,26 +48,16 @@ export class AddMeasureCommand implements Command {
   }
 
   undo(score: Score): Score {
+    // Remove each staff's added bar by its RECORDED id, not the shared insertedIndex: on a desynced
+    // grand staff, splice() clamped the insert to a shorter staff's end, so the added bar isn't at
+    // insertedIndex there — an index-based removal would orphan it (under-delete).
     const newStaves = score.staves.map((staff, index) => {
+      const addedId = this.addedMeasureIds[index];
+      if (!addedId) return staff;
+      const idx = staff.measures.findIndex((m) => m.id === addedId);
+      if (idx === -1) return staff;
       const newMeasures = [...staff.measures];
-      if (newMeasures.length === 0) {
-        return { ...staff, measures: newMeasures };
-      }
-
-      // Check if execute() was called (addedMeasureIds would be populated)
-      const wasExecuted = this.addedMeasureIds.length > 0;
-
-      if (wasExecuted) {
-        // Normal case: remove at recorded index if IDs match
-        if (
-          this.insertedIndex >= 0 &&
-          this.insertedIndex < newMeasures.length &&
-          this.addedMeasureIds[index] &&
-          newMeasures[this.insertedIndex].id === this.addedMeasureIds[index]
-        ) {
-          newMeasures.splice(this.insertedIndex, 1);
-        }
-      }
+      newMeasures.splice(idx, 1);
       return { ...staff, measures: newMeasures };
     });
 
@@ -95,10 +85,12 @@ export class DeleteMeasureCommand implements Command {
     this.deletedMeasures = [];
     this.previousChordTrack = score.chordTrack;
 
-    const newStaves = score.staves.map((staff) => {
+    const newStaves = score.staves.map((staff, index) => {
       const newMeasures = [...staff.measures];
       if (targetIndex < newMeasures.length) {
-        this.deletedMeasures.push(newMeasures[targetIndex]);
+        // Index-aligned by staff (was .push, which misaligned the staff→measure map when a shorter
+        // staff had no bar at targetIndex — undo then restored the wrong measure to the wrong staff).
+        this.deletedMeasures[index] = newMeasures[targetIndex];
         newMeasures.splice(targetIndex, 1);
       }
       return { ...staff, measures: newMeasures };

--- a/src/commands/RemoveTupletCommand.ts
+++ b/src/commands/RemoveTupletCommand.ts
@@ -1,19 +1,18 @@
 import { Command } from './types';
-import { Score } from '@/types';
+import { Score, ScoreEvent } from '@/types';
 import { updateMeasure } from '@/utils/commandHelpers';
 import { getMeasureCapacity } from '@/constants';
 import { sumQuants } from '@/utils/tuplet';
 
 /**
  * Command to remove tuplet metadata from a group of events.
- * Converts tuplet notes back to regular notes.
+ * Converts tuplet notes back to regular notes; the group's reserved (free-space) slots collapse.
  */
 export class RemoveTupletCommand implements Command {
   public readonly type = 'REMOVE_TUPLET';
-  private previousStates: Array<{
-    eventId: string;
-    tuplet?: { ratio: [number, number]; groupSize: number; position: number };
-  }> = [];
+  // Snapshot of the measure's events before execute — a whole-array undo is exact regardless of how
+  // many reserved slots were dropped (which would otherwise shift indices).
+  private prevEvents: ScoreEvent[] | null = null;
 
   constructor(
     private measureIndex: number,
@@ -31,46 +30,32 @@ export class RemoveTupletCommand implements Command {
 
       const { groupSize, position } = targetEvent.tuplet;
       const startIndex = this.eventIndex - position;
+      const groupEnd = startIndex + groupSize;
 
-      const newEvents = [...events];
-      for (let i = 0; i < groupSize; i++) {
-        const idx = startIndex + i;
-        if (idx < 0 || idx >= newEvents.length) continue;
-        newEvents[idx] = { ...newEvents[idx], tuplet: undefined };
-      }
+      // Real members de-tuplet (restore their plain duration); reserved slots are a tuplet-only
+      // construct, so they're DROPPED — the freed space collapses (matching the model's
+      // "delete shifts left" rule), rather than leaving an orphaned reserved rest in plain space.
+      const newEvents = events.flatMap((e, idx) => {
+        if (idx < startIndex || idx >= groupEnd) return [e];
+        if (e.reserved) return [];
+        return [{ ...e, tuplet: undefined }];
+      });
 
-      // Fail closed: stripping the tuplet restores each member's full (nominal) duration, EXPANDING
-      // the bar's footprint. If that would overflow the measure, leave the score untouched rather
-      // than silently create an invalid overfull bar (the API pre-checks and reports the refusal).
+      // Fail closed: stripping the tuplet restores each real member's full (nominal) duration. If
+      // that would overflow the measure, leave the score untouched rather than silently create an
+      // invalid overfull bar (the API pre-checks and reports the refusal).
       if (!measure.isPickup && sumQuants(newEvents).quants > capacity) return false;
 
-      this.previousStates = [];
-      for (let i = 0; i < groupSize; i++) {
-        const idx = startIndex + i;
-        if (idx < 0 || idx >= events.length) continue;
-        this.previousStates.push({
-          eventId: events[idx].id,
-          tuplet: events[idx].tuplet ? { ...events[idx].tuplet } : undefined,
-        });
-      }
-
+      this.prevEvents = events;
       measure.events = newEvents;
       return true;
     });
   }
 
   undo(score: Score): Score {
+    if (!this.prevEvents) return score;
     return updateMeasure(score, this.staffIndex, this.measureIndex, (measure) => {
-      const newEvents = [...measure.events];
-
-      this.previousStates.forEach(({ eventId, tuplet }) => {
-        const eventIndex = newEvents.findIndex((e) => e.id === eventId);
-        if (eventIndex !== -1) {
-          newEvents[eventIndex] = { ...newEvents[eventIndex], tuplet };
-        }
-      });
-
-      measure.events = newEvents;
+      measure.events = this.prevEvents as ScoreEvent[];
       return true;
     });
   }

--- a/src/commands/RemoveTupletCommand.ts
+++ b/src/commands/RemoveTupletCommand.ts
@@ -3,6 +3,7 @@ import { Score, ScoreEvent } from '@/types';
 import { updateMeasure } from '@/utils/commandHelpers';
 import { getMeasureCapacity } from '@/constants';
 import { sumQuants } from '@/utils/tuplet';
+import { eventsWithoutTuplet } from '@/utils/tupletEdit';
 
 /**
  * Command to remove tuplet metadata from a group of events.
@@ -24,27 +25,16 @@ export class RemoveTupletCommand implements Command {
     const capacity = getMeasureCapacity(score.timeSignature);
     return updateMeasure(score, this.staffIndex, this.measureIndex, (measure) => {
       const events = measure.events;
-      const targetEvent = events[this.eventIndex];
+      if (!events[this.eventIndex]?.tuplet) return false;
 
-      if (!targetEvent?.tuplet) return false;
-
-      const { groupSize, position } = targetEvent.tuplet;
-      const startIndex = this.eventIndex - position;
-      const groupEnd = startIndex + groupSize;
-
-      // Real members de-tuplet (restore their plain duration); reserved slots are a tuplet-only
-      // construct, so they're DROPPED — the freed space collapses (matching the model's
-      // "delete shifts left" rule), rather than leaving an orphaned reserved rest in plain space.
-      const newEvents = events.flatMap((e, idx) => {
-        if (idx < startIndex || idx >= groupEnd) return [e];
-        if (e.reserved) return [];
-        return [{ ...e, tuplet: undefined }];
-      });
+      // Real members de-tuplet, reserved slots collapse — shared with the API/UI prechecks.
+      const newEvents = eventsWithoutTuplet(events, this.eventIndex);
 
       // Fail closed: stripping the tuplet restores each real member's full (nominal) duration. If
       // that would overflow the measure, leave the score untouched rather than silently create an
-      // invalid overfull bar (the API pre-checks and reports the refusal).
-      if (!measure.isPickup && sumQuants(newEvents).quants > capacity) return false;
+      // invalid overfull bar (the call sites pre-check and report the refusal). Pickups are validated
+      // at full-bar capacity too (validateMeasure has no pickup exemption), so guard them the same.
+      if (sumQuants(newEvents).quants > capacity) return false;
 
       this.prevEvents = events;
       measure.events = newEvents;

--- a/src/commands/RemoveTupletCommand.ts
+++ b/src/commands/RemoveTupletCommand.ts
@@ -1,6 +1,8 @@
 import { Command } from './types';
 import { Score } from '@/types';
 import { updateMeasure } from '@/utils/commandHelpers';
+import { getMeasureCapacity } from '@/constants';
+import { sumQuants } from '@/utils/tuplet';
 
 /**
  * Command to remove tuplet metadata from a group of events.
@@ -20,6 +22,7 @@ export class RemoveTupletCommand implements Command {
   ) {}
 
   execute(score: Score): Score {
+    const capacity = getMeasureCapacity(score.timeSignature);
     return updateMeasure(score, this.staffIndex, this.measureIndex, (measure) => {
       const events = measure.events;
       const targetEvent = events[this.eventIndex];
@@ -29,20 +32,26 @@ export class RemoveTupletCommand implements Command {
       const { groupSize, position } = targetEvent.tuplet;
       const startIndex = this.eventIndex - position;
 
-      this.previousStates = [];
       const newEvents = [...events];
-
       for (let i = 0; i < groupSize; i++) {
         const idx = startIndex + i;
         if (idx < 0 || idx >= newEvents.length) continue;
+        newEvents[idx] = { ...newEvents[idx], tuplet: undefined };
+      }
 
-        const event = newEvents[idx];
+      // Fail closed: stripping the tuplet restores each member's full (nominal) duration, EXPANDING
+      // the bar's footprint. If that would overflow the measure, leave the score untouched rather
+      // than silently create an invalid overfull bar (the API pre-checks and reports the refusal).
+      if (!measure.isPickup && sumQuants(newEvents).quants > capacity) return false;
+
+      this.previousStates = [];
+      for (let i = 0; i < groupSize; i++) {
+        const idx = startIndex + i;
+        if (idx < 0 || idx >= events.length) continue;
         this.previousStates.push({
-          eventId: event.id,
-          tuplet: event.tuplet ? { ...event.tuplet } : undefined,
+          eventId: events[idx].id,
+          tuplet: events[idx].tuplet ? { ...events[idx].tuplet } : undefined,
         });
-
-        newEvents[idx] = { ...event, tuplet: undefined };
       }
 
       measure.events = newEvents;

--- a/src/commands/TupletCommands.ts
+++ b/src/commands/TupletCommands.ts
@@ -1,7 +1,7 @@
 import { Command } from './types';
 import { Score } from '@/types';
 import { tupletId as createTupletId } from '@/utils/id';
-import { isValidTupletRatio } from '@/utils/tuplet';
+import { isValidTupletRatio, isUniformTupletSelection } from '@/utils/tuplet';
 
 /**
  * Command to apply tuplet metadata to a group of consecutive events.
@@ -45,6 +45,13 @@ export class ApplyTupletCommand implements Command {
     const baseDuration = newEvents[this.startEventIndex].duration;
     if (!isValidTupletRatio(baseDuration, this.ratio)) {
       return score; // Invalid tuplet ratio — leave the score untouched
+    }
+
+    // Members must be uniform: a single baseDuration is stamped on the whole group, so a mixed-
+    // duration selection would mint an incoherent, permanently-invalid group. Fail closed.
+    const groupMembers = newEvents.slice(this.startEventIndex, this.startEventIndex + this.groupSize);
+    if (!isUniformTupletSelection(groupMembers)) {
+      return score;
     }
 
     // Store previous states for undo

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -401,7 +401,10 @@ const Toolbar = forwardRef<ToolbarHandle, ToolbarProps>(
 
         {/* Transient feedback banner (tone by severity) */}
         {errorMsg && (
-          <div className={`riff-Toolbar__error riff-Toolbar__error--${feedbackSeverity}`} role="status">
+          <div
+            className={`riff-Toolbar__error riff-Toolbar__error--${feedbackSeverity}`}
+            role={feedbackSeverity === 'error' ? 'alert' : 'status'}
+          >
             {errorMsg}
           </div>
         )}

--- a/src/exporters/exportNormalize.ts
+++ b/src/exporters/exportNormalize.ts
@@ -15,7 +15,11 @@ import { createRestsForRange } from '@/utils/entry/insertion';
 
 export const padMeasureForExport = (measure: Measure, capacity: number): ScoreEvent[] => {
   const events = measure.events;
-  if (measure.isPickup || events.length === 0) return events;
+  if (measure.isPickup) return events; // genuinely short — leave as-is
+  // An empty (non-pickup) bar — e.g. one the grand-staff parity padding adds after a reflow — must
+  // export as a full-bar rest, not a content-free measure (which is invalid MusicXML/ABC). The
+  // renderer materializes its own whole-bar rest, but exporters go through here, so do it here too.
+  if (events.length === 0) return createRestsForRange(capacity);
 
   const { quants, partialTuplet } = sumQuants(events);
   if (partialTuplet) return events; // mid-edit / broken bar — don't fabricate rests

--- a/src/hooks/api/entry.ts
+++ b/src/hooks/api/entry.ts
@@ -863,9 +863,14 @@ export const createEntryMethods = (
       // closed, but pre-checking lets the API report honestly instead of a no-op ok:true.
       const { groupSize, position } = event.tuplet;
       const groupStart = eventIndex - position;
-      const candidate = measure.events.map((e, i) =>
-        i >= groupStart && i < groupStart + groupSize ? { ...e, tuplet: undefined } : e
-      );
+      // Mirror RemoveTupletCommand EXACTLY: real members de-tuplet, reserved slots are DROPPED (their
+      // freed space collapses). Keeping reserved slots here over-counted the bar and falsely rejected
+      // valid removals (e.g. a triplet of two eighths + one reserved slot → exactly fits on removal).
+      const candidate = measure.events.flatMap((e, i) => {
+        if (i < groupStart || i >= groupStart + groupSize) return [e];
+        if (e.reserved) return [];
+        return [{ ...e, tuplet: undefined }];
+      });
       if (!measure.isPickup && sumQuants(candidate).quants > getMeasureCapacity(getScore().timeSignature)) {
         setResult({
           ok: false,

--- a/src/hooks/api/entry.ts
+++ b/src/hooks/api/entry.ts
@@ -30,7 +30,7 @@ import {
   createRestsForRange,
 } from '@/utils/entry/insertion';
 import { getBreakdownOfQuants, getNoteDuration } from '@/utils/core';
-import { isValidTupletRatio } from '@/utils/tuplet';
+import { isValidTupletRatio, isUniformTupletSelection, sumQuants } from '@/utils/tuplet';
 import { hasTieTarget } from '@/utils/ties';
 import { getMeasureCapacity } from '@/constants';
 
@@ -783,6 +783,19 @@ export const createEntryMethods = (
         return this;
       }
 
+      // Members must share one duration: the group is stamped with a single baseDuration, so a
+      // mixed selection would mint an incoherent, permanently-invalid group. Refuse with feedback.
+      if (!isUniformTupletSelection(measure.events.slice(eventIndex, eventIndex + numNotes))) {
+        setResult({
+          ok: false,
+          status: 'error',
+          method: 'makeTuplet',
+          message: 'Select notes of the same duration to form a tuplet',
+          code: 'NON_UNIFORM_TUPLET',
+        });
+        return this;
+      }
+
       dispatch(
         new ApplyTupletCommand(
           sel.measureIndex,
@@ -840,6 +853,26 @@ export const createEntryMethods = (
           method: 'unmakeTuplet',
           message: 'Selected event is not part of a tuplet',
           code: 'NOT_A_TUPLET',
+        });
+        return this;
+      }
+
+      // Removing a tuplet restores each member's FULL nominal duration (members shrink when grouped),
+      // so it overflows the bar if the freed space was since filled. Refuse rather than silently
+      // create an overfull, invalid bar (#242 "overflow is never silent"). The command also fails
+      // closed, but pre-checking lets the API report honestly instead of a no-op ok:true.
+      const { groupSize, position } = event.tuplet;
+      const groupStart = eventIndex - position;
+      const candidate = measure.events.map((e, i) =>
+        i >= groupStart && i < groupStart + groupSize ? { ...e, tuplet: undefined } : e
+      );
+      if (!measure.isPickup && sumQuants(candidate).quants > getMeasureCapacity(getScore().timeSignature)) {
+        setResult({
+          ok: false,
+          status: 'error',
+          method: 'unmakeTuplet',
+          message: 'Cannot remove tuplet: the notes’ full duration would overflow the measure',
+          code: 'DURATION_OVERFLOW',
         });
         return this;
       }

--- a/src/hooks/api/entry.ts
+++ b/src/hooks/api/entry.ts
@@ -15,7 +15,7 @@ import { DeleteEventCommand } from '@/commands/DeleteEventCommand';
 import { FillReservedSlotCommand } from '@/commands/FillReservedSlotCommand';
 import { InsertTupletMemberCommand } from '@/commands/InsertTupletMemberCommand';
 import { InsertEventCommand } from '@/commands/InsertEventCommand';
-import { getTupletRun } from '@/utils/tupletEdit';
+import { getTupletRun, eventsWithoutTuplet } from '@/utils/tupletEdit';
 import { ApplyTupletCommand } from '@/commands/TupletCommands';
 import { RemoveTupletCommand } from '@/commands/RemoveTupletCommand';
 import { UpdateNoteCommand } from '@/commands/UpdateNoteCommand';
@@ -861,17 +861,11 @@ export const createEntryMethods = (
       // so it overflows the bar if the freed space was since filled. Refuse rather than silently
       // create an overfull, invalid bar (#242 "overflow is never silent"). The command also fails
       // closed, but pre-checking lets the API report honestly instead of a no-op ok:true.
-      const { groupSize, position } = event.tuplet;
-      const groupStart = eventIndex - position;
-      // Mirror RemoveTupletCommand EXACTLY: real members de-tuplet, reserved slots are DROPPED (their
-      // freed space collapses). Keeping reserved slots here over-counted the bar and falsely rejected
-      // valid removals (e.g. a triplet of two eighths + one reserved slot → exactly fits on removal).
-      const candidate = measure.events.flatMap((e, i) => {
-        if (i < groupStart || i >= groupStart + groupSize) return [e];
-        if (e.reserved) return [];
-        return [{ ...e, tuplet: undefined }];
-      });
-      if (!measure.isPickup && sumQuants(candidate).quants > getMeasureCapacity(getScore().timeSignature)) {
+      // Shares the exact removal logic with RemoveTupletCommand (real members de-tuplet, reserved
+      // slots dropped) so the precheck can't disagree with the command. Pickups are validated at
+      // full-bar capacity too — guard them the same (no isPickup exemption).
+      const candidate = eventsWithoutTuplet(measure.events, eventIndex);
+      if (sumQuants(candidate).quants > getMeasureCapacity(getScore().timeSignature)) {
         setResult({
           ok: false,
           status: 'error',

--- a/src/hooks/api/modification.ts
+++ b/src/hooks/api/modification.ts
@@ -260,9 +260,10 @@ export const createModificationMethods = (
     transposeDiatonic(steps) {
       /** @tested src/__tests__/ScoreAPI.modification.test.tsx */
       const sel = selectionRef.current;
-      // Report a no-op as failure (matches transpose()); TransposeSelectionCommand handles both the
-      // primary selection and a multi-note selection, so only reject when BOTH are empty.
-      if (sel.measureIndex === null && (!sel.selectedNotes || sel.selectedNotes.length === 0)) {
+      // Report a no-op as failure, matching transpose() and TransposeSelectionCommand.execute, which
+      // bails on measureIndex === null regardless of selectedNotes. (The old `&& selectedNotes empty`
+      // let a null-measure selection through to a silent no-op falsely reported as success.)
+      if (sel.measureIndex === null) {
         setResult({
           ok: false,
           status: 'error',
@@ -384,12 +385,11 @@ export const createModificationMethods = (
           details: { eventId: sel.eventId },
         });
       } else {
+        // Consistent with the registry (NO_SELECTION = error) and every other NO_SELECTION site —
+        // nothing was deleted, so report it as a failure rather than a misleading ok:true warning.
         setResult({
-          ok: true,
-          status: 'warning',
           method: 'deleteSelected',
-          message: 'Nothing selected to delete',
-          code: 'NO_SELECTION',
+          ...refuse('NO_SELECTION', { message: 'Nothing selected to delete' }),
         });
       }
       return this;
@@ -410,6 +410,18 @@ export const createModificationMethods = (
 
     setTimeSignature(sig) {
       /** @tested src/__tests__/ScoreAPI.modification.test.tsx */
+      // No-op when unchanged — don't dispatch a command that would pollute the undo stack (mirrors
+      // the UI path and setMeasurePickup).
+      if (sig === ctx.getScore().timeSignature) {
+        setResult({
+          ok: true,
+          status: 'info',
+          method: 'setTimeSignature',
+          message: `Time signature already ${sig}`,
+          details: { signature: sig },
+        });
+        return this;
+      }
       // A tuplet group is atomic; if one can't fit a whole bar of the new meter, reflow has no valid
       // placement — refuse rather than corrupt the score into an overfull bar. (#256)
       if (!tupletsFitTimeSignature(ctx.getScore().staves, sig)) {

--- a/src/hooks/api/navigation.ts
+++ b/src/hooks/api/navigation.ts
@@ -5,6 +5,7 @@ import { getFirstNoteId, getNoteDuration } from '@/utils/core';
 import { calculateVerticalNavigation } from '@/utils/navigation/vertical';
 import { calculateNextSelection } from '@/utils/navigation/horizontal';
 import { SelectEventCommand } from '@/commands/selection';
+import { refuse } from '@/refusals';
 
 /**
  * Navigation method names provided by this factory
@@ -69,11 +70,8 @@ export const createNavigationMethods = (
 
         if (!navResult) {
           setResult({
-            ok: true,
-            status: 'info',
             method: 'move',
-            message: `Cannot move ${direction} (boundary)`,
-            code: 'BOUNDARY_REACHED',
+            ...refuse('BOUNDARY_REACHED', { message: `Cannot move ${direction} (boundary)` }),
           });
           return this;
         }
@@ -165,12 +163,11 @@ export const createNavigationMethods = (
             },
           });
         } else {
+          // Single-sourced severity (info) via the registry — the vertical case used to emit
+          // 'warning', contradicting the horizontal case and the registry. (#13)
           setResult({
-            ok: true,
-            status: 'warning',
             method: 'move',
-            message: `Cannot move ${direction} (boundary reached)`,
-            code: 'BOUNDARY_REACHED',
+            ...refuse('BOUNDARY_REACHED', { message: `Cannot move ${direction} (boundary reached)` }),
           });
         }
       }
@@ -195,22 +192,32 @@ export const createNavigationMethods = (
       let targetMeasureIndex: number;
       let targetEventIndex: number;
 
+      // Reserved tuplet slots are blank free space (packed at a group's end) — never a jump target.
+      const firstRealIndex = (events: typeof measures[number]['events']) => {
+        const idx = events.findIndex((e) => !e.reserved);
+        return idx < 0 ? 0 : idx;
+      };
+      const lastRealIndex = (events: typeof measures[number]['events']) => {
+        for (let i = events.length - 1; i >= 0; i--) if (!events[i].reserved) return i;
+        return 0;
+      };
+
       switch (target) {
         case 'start-score':
           targetMeasureIndex = 0;
-          targetEventIndex = 0;
+          targetEventIndex = firstRealIndex(measures[0].events);
           break;
         case 'end-score':
           targetMeasureIndex = measures.length - 1;
-          targetEventIndex = Math.max(0, measures[targetMeasureIndex].events.length - 1);
+          targetEventIndex = lastRealIndex(measures[targetMeasureIndex].events);
           break;
         case 'start-measure':
           targetMeasureIndex = sel.measureIndex ?? 0;
-          targetEventIndex = 0;
+          targetEventIndex = firstRealIndex(measures[targetMeasureIndex]?.events ?? []);
           break;
         case 'end-measure':
           targetMeasureIndex = sel.measureIndex ?? 0;
-          targetEventIndex = Math.max(0, measures[targetMeasureIndex]?.events.length - 1);
+          targetEventIndex = lastRealIndex(measures[targetMeasureIndex]?.events ?? []);
           break;
         default:
           setResult({

--- a/src/hooks/api/navigation.ts
+++ b/src/hooks/api/navigation.ts
@@ -314,14 +314,17 @@ export const createNavigationMethods = (
 
       const measure = staff.measures[measureIndex];
 
-      // Walk events to find event at quant position
+      // Walk events to find event at quant position. Use the tuplet ratio (footprint quants) so the
+      // quant axis matches every other walker (getStops, chord anchors); a plain nominal duration
+      // mis-maps every position after a tuplet. Skip reserved placeholder slots — they draw nothing,
+      // so a quant inside a tuplet's free space must not select the blank slot.
       let currentQuant = 0;
       let found = false;
       for (let i = 0; i < measure.events.length; i++) {
         const event = measure.events[i];
-        const eventDuration = getNoteDuration(event.duration, event.dotted);
+        const eventDuration = getNoteDuration(event.duration, event.dotted, event.tuplet);
 
-        if (currentQuant <= quant && quant < currentQuant + eventDuration) {
+        if (!event.reserved && currentQuant <= quant && quant < currentQuant + eventDuration) {
           // Found the event at this quant position
           selectionEngine.dispatch(
             new SelectEventCommand({

--- a/src/hooks/editor/useModifiers.ts
+++ b/src/hooks/editor/useModifiers.ts
@@ -160,11 +160,14 @@ export const useModifiers = ({
         });
 
         if (skipped > 0) {
+          // Intentional tone split: this human-facing banner uses a gentle 'warning' (and its own
+          // count-pluralized wording), NOT the API's REFUSALS.DURATION_OVERFLOW severity ('error').
+          // The API result is for scripts; the banner is a soft "didn't fit" nudge. (#20)
           setFeedback(
             applied === 0
               ? "Can't lengthen the note — not enough room left in the measure"
               : `Lengthened ${applied}; ${skipped} didn't fit the measure`,
-            'warning' // a gentle "didn't fit" notice, not a hard error
+            'warning'
           );
         } else if (applied > 0) {
           setFeedback(null);
@@ -235,11 +238,12 @@ export const useModifiers = ({
     });
 
     if (skipped > 0) {
+      // Intentional tone split — gentle banner 'warning', not the API DURATION_OVERFLOW 'error'. (#20)
       setFeedback(
         applied === 0
           ? "Can't add a dot — not enough room left in the measure"
           : `Dotted ${applied}; ${skipped} didn't fit the measure`,
-        'warning' // a gentle "didn't fit" notice, not a hard error
+        'warning'
       );
     } else if (applied > 0) {
       setFeedback(null);

--- a/src/hooks/note/useNoteEntry.ts
+++ b/src/hooks/note/useNoteEntry.ts
@@ -177,6 +177,24 @@ export function useNoteEntry({
       const currentStaffData = getActiveStaff(currentScore, currentStaffIndex);
 
       const newMeasures = [...currentStaffData.measures];
+
+      // A preview can target ONE PAST THE END — a full last bar whose APPEND overflowed into a fresh
+      // bar (useHoverPreview bumps measureIndex+1). That measure doesn't exist yet: the capacity check
+      // on the empty phantom would pass and the dispatched command would then no-op, silently losing
+      // the note (Enter hit this; click auto-created). Create the bar, then retarget it.
+      if (!newMeasures[measureIndex]) {
+        if (measureIndex === currentStaffData.measures.length) {
+          dispatch(new AddMeasureCommand());
+          addNoteToMeasureCallback(
+            measureIndex,
+            { ...newNote, staffIndex: currentStaffIndex },
+            false,
+            { mode: 'APPEND', index: 0 }
+          );
+        }
+        return;
+      }
+
       const targetMeasure = { ...newMeasures[measureIndex] };
       if (!targetMeasure.events) targetMeasure.events = [];
 

--- a/src/hooks/note/useNoteEntry.ts
+++ b/src/hooks/note/useNoteEntry.ts
@@ -177,24 +177,6 @@ export function useNoteEntry({
       const currentStaffData = getActiveStaff(currentScore, currentStaffIndex);
 
       const newMeasures = [...currentStaffData.measures];
-
-      // A preview can target ONE PAST THE END — a full last bar whose APPEND overflowed into a fresh
-      // bar (useHoverPreview bumps measureIndex+1). That measure doesn't exist yet: the capacity check
-      // on the empty phantom would pass and the dispatched command would then no-op, silently losing
-      // the note (Enter hit this; click auto-created). Create the bar, then retarget it.
-      if (!newMeasures[measureIndex]) {
-        if (measureIndex === currentStaffData.measures.length) {
-          dispatch(new AddMeasureCommand());
-          addNoteToMeasureCallback(
-            measureIndex,
-            { ...newNote, staffIndex: currentStaffIndex },
-            false,
-            { mode: 'APPEND', index: 0 }
-          );
-        }
-        return;
-      }
-
       const targetMeasure = { ...newMeasures[measureIndex] };
       if (!targetMeasure.events) targetMeasure.events = [];
 

--- a/src/hooks/useTupletActions.ts
+++ b/src/hooks/useTupletActions.ts
@@ -3,6 +3,7 @@ import { ApplyTupletCommand } from '@/commands/TupletCommands';
 import { RemoveTupletCommand } from '@/commands/RemoveTupletCommand';
 import { Command } from '@/commands/types';
 import { Score, Selection, ScoreEvent } from '@/types';
+import { isUniformTupletSelection } from '@/utils/tuplet';
 
 /**
  * Hook providing tuplet manipulation actions.
@@ -133,8 +134,12 @@ export const useTupletActions = (
       const eventIndex = measure.events.findIndex((e: ScoreEvent) => e.id === selection.eventId);
       if (eventIndex === -1) return false;
 
-      // Check if we have enough consecutive events
-      return eventIndex + groupSize <= measure.events.length;
+      // Enough consecutive events…
+      if (eventIndex + groupSize > measure.events.length) return false;
+
+      // …and they must be uniform — a single baseDuration is stamped on the group, so a mixed
+      // selection would mint an incoherent, permanently-invalid tuplet. Don't offer it.
+      return isUniformTupletSelection(measure.events.slice(eventIndex, eventIndex + groupSize));
     },
     [selection, scoreRef]
   );

--- a/src/hooks/useTupletActions.ts
+++ b/src/hooks/useTupletActions.ts
@@ -3,7 +3,9 @@ import { ApplyTupletCommand } from '@/commands/TupletCommands';
 import { RemoveTupletCommand } from '@/commands/RemoveTupletCommand';
 import { Command } from '@/commands/types';
 import { Score, Selection, ScoreEvent } from '@/types';
-import { isUniformTupletSelection } from '@/utils/tuplet';
+import { isUniformTupletSelection, sumQuants } from '@/utils/tuplet';
+import { eventsWithoutTuplet } from '@/utils/tupletEdit';
+import { getMeasureCapacity } from '@/constants';
 
 /**
  * Hook providing tuplet manipulation actions.
@@ -103,6 +105,15 @@ export const useTupletActions = (
     const event = measure.events[eventIndex];
     if (!event.tuplet) {
       console.warn('Selected event is not part of a tuplet');
+      return false;
+    }
+
+    // Precheck (mirrors RemoveTupletCommand's fail-closed guard via the shared helper): if restoring
+    // the members' full durations would overflow the bar, don't dispatch a doomed command — that
+    // would no-op yet still land a dead entry on the undo stack.
+    const candidate = eventsWithoutTuplet(measure.events, eventIndex);
+    if (sumQuants(candidate).quants > getMeasureCapacity(currentScore.timeSignature)) {
+      console.warn('Cannot remove tuplet: the notes’ full duration would overflow the measure');
       return false;
     }
 

--- a/src/refusals.ts
+++ b/src/refusals.ts
@@ -59,6 +59,7 @@ export type RefusalCode =
   | 'INSUFFICIENT_EVENTS'
   | 'NESTED_TUPLET_NOT_SUPPORTED'
   | 'INVALID_TUPLET_RATIO'
+  | 'NON_UNIFORM_TUPLET'
   | 'NOT_A_TUPLET'
   // --- ties ---
   | 'NO_TIE_TARGET'
@@ -156,6 +157,7 @@ export const REFUSALS: Record<RefusalCode, RefusalSpec> = {
   INSUFFICIENT_EVENTS: { severity: 'error', message: s('Not enough events for a tuplet') },
   NESTED_TUPLET_NOT_SUPPORTED: { severity: 'error', message: s('Target events already contain a tuplet') },
   INVALID_TUPLET_RATIO: { severity: 'error', message: s('Invalid tuplet ratio') },
+  NON_UNIFORM_TUPLET: { severity: 'error', message: s('Select notes of the same duration to form a tuplet') },
   NOT_A_TUPLET: { severity: 'warning', message: s('Selected event is not part of a tuplet') },
 
   // --- ties ---

--- a/src/services/chord/types.ts
+++ b/src/services/chord/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ChordDisplayConfig } from '@/types';
+import type { RefusalCode } from '@/refusals';
 
 // ============================================================================
 // PARSE RESULT TYPES
@@ -27,11 +28,13 @@ export interface ChordComponents {
   bass: string | null; // 'E' for C/E, null otherwise
 }
 
-export type ChordErrorCode =
-  | 'CHORD_EMPTY'
-  | 'CHORD_INVALID_ROOT'
-  | 'CHORD_INVALID_QUALITY'
-  | 'CHORD_INVALID_BASS';
+// Derived from the unified RefusalCode vocabulary (Result.code is narrowed to it, and chords.ts emits
+// `code: parseResult.code`), so the two can't drift — Extract resolves to `never` for any name not in
+// RefusalCode, surfacing as a compile error where the parser returns it.
+export type ChordErrorCode = Extract<
+  RefusalCode,
+  'CHORD_EMPTY' | 'CHORD_INVALID_ROOT' | 'CHORD_INVALID_QUALITY' | 'CHORD_INVALID_BASS'
+>;
 
 // ============================================================================
 // NOTATION TYPES

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -251,35 +251,36 @@ export const reflowScore = (measures: Measure[], newTimeSignature: string): Meas
       commitMeasure(isFillingPickup);
       if (isFillingPickup) isFillingPickup = false;
 
-      // 2. Handle the overflow (remainder)
-      const remainingQuants = eventDuration - available;
-      if (remainingQuants > 0) {
-        const remainderParts = getBreakdownOfQuants(remainingQuants);
+      // 2. Handle the overflow (remainder). Re-bar in BAR-SIZED chunks: a single note value can
+      // exceed a whole bar of the new meter (e.g. a half note reflowed to 3/8) — breaking the entire
+      // remainder down at once then placing the fragments would dump an over-capacity fragment into a
+      // bar (overfull) and fire the pre-commit on an empty buffer (a spurious empty bar). Instead fill
+      // each fresh bar up to maxQuants and split-and-tie at every bar line.
+      let remaining = eventDuration - available;
+      while (remaining > 0) {
+        const chunk = Math.min(remaining, maxQuants);
+        const isFinalChunk = chunk === remaining;
+        const parts = getBreakdownOfQuants(chunk);
 
-        remainderParts.forEach((part, partIndex) => {
-          // Every fragment but the last ties to the next fragment of the same split note; the LAST
-          // fragment carries each note's ORIGINAL onward tie, PER-NOTE (not broadcast from notes[0],
-          // which silently dropped per-note chord-tie granularity). repairTies later clears the last
-          // fragment's tie if that onward target didn't survive re-barring.
-          const isLastFragment = partIndex === remainderParts.length - 1;
-          const newEvent = {
+        parts.forEach((part, partIndex) => {
+          // Every fragment but the very last ties onward to its continuation; the LAST fragment of the
+          // FINAL chunk carries each note's ORIGINAL onward tie, PER-NOTE. repairTies later clears it
+          // if that onward target didn't survive re-barring.
+          const isLastFragment = isFinalChunk && partIndex === parts.length - 1;
+          currentMeasureEvents.push({
             ...event,
             id: eventId(),
             duration: part.duration,
             dotted: part.dotted,
             notes: event.notes.map((n) => ({ ...n, tied: isLastFragment ? !!n.tied : true })),
-          };
-
-          // Handle edge case: If a single note is massive (larger than a full measure),
-          // strict logic would require a recursive split.
-          // For now, we assume standard notes fit within 'maxQuants' or simply overflow.
-          if (currentMeasureQuants + part.quants > maxQuants) {
-            commitMeasure(false);
-          }
-
-          currentMeasureEvents.push(newEvent);
+          });
           currentMeasureQuants += part.quants;
         });
+
+        remaining -= chunk;
+        // The bar is now full to maxQuants; close it and continue with a fresh one. The final
+        // (under-full) chunk stays buffered for the next event or the cleanup commit.
+        if (remaining > 0) commitMeasure(false);
       }
     }
     i++;

--- a/src/utils/entry/eventInserter.ts
+++ b/src/utils/entry/eventInserter.ts
@@ -5,6 +5,11 @@
  * what changes need to be made without actually dispatching commands,
  * making them easy to test and reason about.
  *
+ * NOTE: not yet wired to a caller — this is the intended foundation for the surface-agnostic
+ * insertion planner described in docs/migration/plan-unified-events.md (mouse/keyboard/MIDI/API +
+ * paste). Kept (not deleted) as that documented roadmap's extension point; `maxQuants` is already
+ * threaded through `InsertionContext` so the planner can't assume 4/4 (#242) when it's adopted.
+ *
  * @module utils/entry/eventInserter
  */
 

--- a/src/utils/navigation/vertical.ts
+++ b/src/utils/navigation/vertical.ts
@@ -82,8 +82,9 @@ export const calculateCrossStaffSelection = (
     const start = targetQuant;
     const end = targetQuant + duration;
 
-    // Check overlap: if currentQuantStart falls within [start, end)
-    if (currentQuantStart >= start && currentQuantStart < end) {
+    // Check overlap: if currentQuantStart falls within [start, end). Skip reserved slots (blank free
+    // space) so the cursor never lands on a placeholder.
+    if (!e.reserved && currentQuantStart >= start && currentQuantStart < end) {
       targetEvent = e;
       break;
     }
@@ -237,7 +238,8 @@ export const calculateVerticalNavigation = (
           const start = targetQuant;
           const end = targetQuant + duration;
 
-          if (currentQuantStart >= start && currentQuantStart < end) {
+          // Skip reserved slots (blank free space) — never a landing target.
+          if (!e.reserved && currentQuantStart >= start && currentQuantStart < end) {
             targetEvent = e;
             break;
           }
@@ -421,7 +423,9 @@ export const calculateVerticalNavigation = (
         const start = targetQuant;
         const end = targetQuant + duration;
 
-        if (currentQuantStart >= start && currentQuantStart < end) {
+        // A reserved slot is blank free space — never a landing target. If the aligned quant falls in
+        // one, skip it so we fall through to the no-event/ghost-cursor branch below.
+        if (!e.reserved && currentQuantStart >= start && currentQuantStart < end) {
           targetEvent = e;
           break;
         }

--- a/src/utils/navigation/vertical.ts
+++ b/src/utils/navigation/vertical.ts
@@ -8,6 +8,7 @@
  */
 
 import { calculateTotalQuants, getNoteDuration } from '../core';
+import { quantsEqual } from '../tuplet';
 import { getMidi } from '@/services/MusicService';
 import { CONFIG } from '@/config';
 import {
@@ -447,7 +448,11 @@ export const calculateVerticalNavigation = (
       } else {
         // No event at this quant - show ghost cursor with adjusted duration
         const totalQuants = calculateTotalQuants(targetMeasure.events);
-        const availableQuants = currentQuantsPerMeasure - totalQuants;
+        // Snap to 0 when the bar is full within tuplet FP drift (parity with getStops' quantsEqual):
+        // a complete tuplet's member sum can read 63.9999 not 64, falsely leaving a sliver of space.
+        const availableQuants = quantsEqual(totalQuants, currentQuantsPerMeasure)
+          ? 0
+          : currentQuantsPerMeasure - totalQuants;
         const adjusted = getAdjustedDuration(availableQuants, activeDuration, isDotted);
 
         if (adjusted) {
@@ -535,7 +540,10 @@ export const calculateVerticalNavigation = (
     } else {
       // No event - show ghost cursor with adjusted duration
       const totalQuants = calculateTotalQuants(cycleMeasure.events);
-      const availableQuants = currentQuantsPerMeasure - totalQuants;
+      // Snap to 0 when full within tuplet FP drift (parity with getStops' quantsEqual).
+      const availableQuants = quantsEqual(totalQuants, currentQuantsPerMeasure)
+        ? 0
+        : currentQuantsPerMeasure - totalQuants;
       const adjusted = getAdjustedDuration(availableQuants, activeDuration, isDotted);
 
       if (adjusted) {

--- a/src/utils/selection.ts
+++ b/src/utils/selection.ts
@@ -162,7 +162,9 @@ export const getLinearizedNotes = (score: Score): NoteContext[] => {
   score.staves.forEach((staff, staffInd) => {
     staff.measures.forEach((measure, measureInd) => {
       measure.events.forEach((event) => {
-        if (event.notes && event.notes.length > 0) {
+        // Skip reserved tuplet slots — they're blank free space, never a selectable target. Including
+        // them put the placeholder into a range selection, so destructive ops then hit empty space.
+        if (event.notes && event.notes.length > 0 && !event.reserved) {
           event.notes.forEach((note) => {
             notes.push({
               staffIndex: staffInd,

--- a/src/utils/tuplet.ts
+++ b/src/utils/tuplet.ts
@@ -45,6 +45,19 @@ export const isValidTupletRatio = (baseDuration: string, ratio: [number, number]
 export const quantsEqual = (a: number, b: number): boolean => Math.abs(a - b) <= QUANT_EPSILON;
 
 /**
+ * Whether a selected run can form a COHERENT tuplet: every member must share one duration (and dot),
+ * because the group is stamped with a SINGLE `baseDuration` (taken from the first member) and is
+ * rendered/accounted against it. A mixed selection (e.g. quarter + eighth + eighth) mints a group
+ * whose member footprints don't sum to an integer → a permanently `incomplete-tuplet`-invalid bar.
+ * Nested tuplets are rejected separately by the callers.
+ */
+export const isUniformTupletSelection = (events: ScoreEvent[]): boolean => {
+  if (events.length === 0) return false;
+  const { duration, dotted } = events[0];
+  return events.every((e) => e.duration === duration && !!e.dotted === !!dotted);
+};
+
+/**
  * Total quant length of an event list. A COMPLETE tuplet group is accounted by its members'
  * footprint rounded to the nearest integer (eliminating IEEE-754 drift; correct for uniform
  * and for dotted/mixed members alike). Consecutive events sharing a `tuplet.id` form a group;

--- a/src/utils/tupletEdit.ts
+++ b/src/utils/tupletEdit.ts
@@ -51,7 +51,9 @@ export const getTupletRun = (
       break;
     }
   }
-  return { start, end };
+  // eventIndex is a guaranteed tuplet member, so the run must contain it. Clamp against a corrupt
+  // position/groupSize that would otherwise yield a degenerate run excluding it (e.g. {start, start-1}).
+  return { start: Math.min(start, eventIndex), end: Math.max(end, eventIndex) };
 };
 
 /**

--- a/src/utils/tupletEdit.ts
+++ b/src/utils/tupletEdit.ts
@@ -57,6 +57,27 @@ export const getTupletRun = (
 };
 
 /**
+ * The measure's events after removing the tuplet group that contains `eventIndex`: real members
+ * de-tuplet (their plain duration is restored), and reserved slots are DROPPED — the freed space
+ * collapses (matching "delete shifts left"), never leaving an orphaned reserved rest in plain space.
+ * Returns the original array unchanged if the event isn't a tuplet member.
+ *
+ * Single source for RemoveTupletCommand + the un-make capacity prechecks (API + UI) so they can't
+ * disagree on group bounds / reserved handling / a corrupt `position`.
+ */
+export const eventsWithoutTuplet = (events: ScoreEvent[], eventIndex: number): ScoreEvent[] => {
+  const tuplet = events[eventIndex]?.tuplet;
+  if (!tuplet) return events;
+  const start = eventIndex - (tuplet.position ?? 0);
+  const end = start + tuplet.groupSize;
+  return events.flatMap((e, i) => {
+    if (i < start || i >= end) return [e];
+    if (e.reserved) return [];
+    return [{ ...e, tuplet: undefined }];
+  });
+};
+
+/**
  * A reserved placeholder slot carrying `template`'s duration/dotted/tuplet (so it occupies the
  * deleted member's footprint and keeps the group's span exact). `reservedId` is supplied by the
  * caller so it stays stable across undo→redo (redo re-runs execute).


### PR DESCRIPTION
Remediation from a deep adversarial QA pass over `dev` (25 confirmed findings), the follow-ups from
Codex's reviews of this PR, **and a second adversarial re-QA of the fix commits themselves**.
**9 commits.** Full suite green (161 suites / 2931 tests), tsc + lint clean. `dev`'s content is fully
contained, so this applies cleanly.

**Closes #262** (deep-QA nits — 3 fixed, 1 resolved-as-intentional-keep).

## For musicians / users
- **Make/Unmake tuplet can't corrupt a bar.** Removing a tuplet that would overflow the measure is
  refused (was a silent overfill) — including in pickup bars; making a tuplet from mixed note
  durations is refused (was a permanently-broken bar). The toolbar disables tuplet buttons for mixed
  selections.
- **Adding a note onto a rest works** — it converts the rest to that note instead of silently
  swallowing it.
- **The cursor never lands on blank tuplet space.** Jump-to-end, cross-staff up/down, and range
  selection skip a tuplet's empty reserved slots; removing a tuplet collapses that free space.
- **Changing the time signature is safer.** A note larger than the new bar re-bars cleanly (no stray
  empty/overfull bars), and exporting a reflowed grand staff no longer emits invalid files.

## For developers
- **Model invariants** (#1,#2,#5,#7): tuplet make/unmake honor capacity + uniformity (pickups guarded
  at full-bar capacity too — validateMeasure has no pickup exemption); reflow re-bars oversized notes
  in bar-sized chunks; RemoveTuplet drops reserved members (no orphan rest), exact whole-array undo.
  The un-tuplet removal logic is single-sourced in `eventsWithoutTuplet()` so the command + both
  prechecks can't diverge.
- **Reserved-slot SSOT** (#3,#9,#10,#16): selectAtQuant uses tuplet footprint; getLinearizedNotes,
  jump, and the cross-staff overlap walks all skip reserved slots — one invariant ("reserved space is
  never a target") applied at each source. Both `api.unmakeTuplet()` and the UI `removeTuplet`
  pre-check via the shared helper so neither dispatches a doomed command.
- **Commands/undo** (#8,#18): Add/DeleteMeasure undo correct on a desynced grand staff (id-/index-aligned).
- **API result consistency** (#13,#14,#19,#21): BOUNDARY_REACHED + NO_SELECTION single-sourced through
  the refusal registry; no-op setTimeSignature doesn't pollute undo; transposeDiatonic rejects what the
  command can't act on. The overflow-banner vs API-severity split is documented as intentional (#20).
- **Export** (#6,#15): empty (non-pickup) bars export as full-bar rests — also fixes the empty-staff
  "no rest" half of #246 (the XSD-fixture half stays with #235).
- **Entry** (#4): chord-onto-rest promotes the rest to a note at the command level (covers API +
  interactive), with a faithful undo.
- **Robustness / nits** (#17,#22,#23,#24,#25): getTupletRun clamps its legacy fallback to include the
  queried member; vertical ghost availability snaps via `quantsEqual`; `ChordErrorCode` derived from
  `RefusalCode`; feedback banner uses `role="alert"`/`"status"` by severity; `eventInserter.ts` kept +
  annotated as the unified-events foundation.

> Note: the `#1…#25` above are internal deep-QA finding numbers, **not** GitHub issues — only #262 is
> closed by this PR. Related/partial: #246 (export half), #235 (XSD validation), #209 (fail-fast/soft).

## Deferred to tracked issues (not fixed here)
- **#12** chord global-time re-anchoring across reflow → **#255**.
- **#11** keyboard Enter loses a note appending past a full last bar → **#263** (initial fix reverted
  as unsafe: recursed before `scoreRef` re-synced; needs a batched create-and-place).
- **cross-staff tuplet-fill ghost** (vertical nav into reserved space) → **#264** (Codex P2; the minimal
  "don't land on blank" fix shipped, the fill-ghost parity is deferred).

Out of scope (filed separately): an audio-lane QA gap (TimelineService tie-merge isn't the SSOT) → #261.
