### PR TITLE
Close the loop on M2 interactive correctness (#261, #263, #264, #257)

### DIFF
--- a/src/__tests__/Interaction.test.tsx
+++ b/src/__tests__/Interaction.test.tsx
@@ -229,6 +229,59 @@ describe('ScoreEditor Interactions', () => {
     });
   });
 
+  test('Undo does NOT clobber a selection the user made after the delete (#257 / Codex P2)', async () => {
+    const score = createDefaultScore();
+    render(
+      <ThemeProvider>
+        <ScoreEditor label="Interaction Test" initialData={score} />
+      </ThemeProvider>
+    );
+
+    // Add note A in measure 0 and note B in measure 1.
+    const m0 = screen.getByTestId('measure-hit-area-0-0');
+    fireEvent.mouseMove(m0, { clientX: 50, clientY: 110 });
+    await screen.findByTestId('ghost-note');
+    fireEvent.click(m0, { clientX: 50, clientY: 110 });
+
+    const m1 = screen.getByTestId('measure-hit-area-1-0');
+    fireEvent.mouseMove(m1, { clientX: 50, clientY: 110 });
+    await screen.findByTestId('ghost-note');
+    fireEvent.click(m1, { clientX: 50, clientY: 110 });
+
+    const chords = screen.getAllByTestId(/^chord-[^t]/);
+    expect(chords).toHaveLength(2);
+    const idA = chords[0].getAttribute('data-testid')!; // measure 0
+    const idB = chords[1].getAttribute('data-testid')!; // measure 1
+
+    const container = screen.getByTestId('score-canvas-container');
+    fireEvent.focus(container);
+    fireEvent.mouseEnter(container);
+
+    // Select A, delete it (empties measure 0 → stashes A's coord).
+    fireEvent.click(screen.getByTestId(idA));
+    await waitFor(() => expect(screen.getByTestId(idA)).toHaveAttribute('data-selected', 'true'));
+    fireEvent.keyDown(window, { key: 'Backspace', code: 'Backspace', keyCode: 8 });
+    await waitFor(() => expect(screen.queryByTestId(idA)).toBeNull());
+
+    // The user moves on: select B.
+    fireEvent.click(screen.getByTestId(idB));
+    await waitFor(() => expect(screen.getByTestId(idB)).toHaveAttribute('data-selected', 'true'));
+
+    // Undo restores A — the user's selection (B) must NOT be clobbered. Crucially this also DROPS
+    // the stash (the user moved on), which the next assertion proves.
+    fireEvent.keyDown(window, { key: 'z', code: 'KeyZ', metaKey: true });
+    await waitFor(() => expect(screen.queryByTestId(idA)).not.toBeNull());
+    expect(screen.getByTestId(idB)).toHaveAttribute('data-selected', 'true');
+    expect(screen.getByTestId(idA)).not.toHaveAttribute('data-selected', 'true');
+
+    // Sentinel for the clear (Codex P2): a SECOND undo removes B and empties the selection — a score
+    // change with no selection. If the stash had survived the first undo, the now-restored A would be
+    // spuriously re-selected here. With the stash cleared, A stays unselected.
+    fireEvent.keyDown(window, { key: 'z', code: 'KeyZ', metaKey: true });
+    await waitFor(() => expect(screen.queryByTestId(idB)).toBeNull());
+    expect(screen.getByTestId(idA)).not.toHaveAttribute('data-selected', 'true');
+  });
+
   test('Cursor auto-advances after APPENDing a note', async () => {
     const score = createDefaultScore();
     render(

--- a/src/__tests__/Interaction.test.tsx
+++ b/src/__tests__/Interaction.test.tsx
@@ -270,7 +270,7 @@ describe('ScoreEditor Interactions', () => {
     // Undo restores A — the user's selection (B) must NOT be clobbered. Crucially this also DROPS
     // the stash (the user moved on), which the next assertion proves.
     fireEvent.keyDown(window, { key: 'z', code: 'KeyZ', metaKey: true });
-    await waitFor(() => expect(screen.queryByTestId(idA)).not.toBeNull());
+    await screen.findByTestId(idA);
     expect(screen.getByTestId(idB)).toHaveAttribute('data-selected', 'true');
     expect(screen.getByTestId(idA)).not.toHaveAttribute('data-selected', 'true');
 

--- a/src/__tests__/Interaction.test.tsx
+++ b/src/__tests__/Interaction.test.tsx
@@ -189,6 +189,46 @@ describe('ScoreEditor Interactions', () => {
     const remainingChords = screen.queryAllByTestId(/^chord-[^t]/);
     expect(remainingChords).toHaveLength(0);
   });
+
+  test('Undo of a delete that emptied the selection restores the selection (#257)', async () => {
+    const score = createDefaultScore();
+    render(
+      <ThemeProvider>
+        <ScoreEditor label="Interaction Test" initialData={score} />
+      </ThemeProvider>
+    );
+
+    const hitArea = screen.getByTestId('measure-hit-area-0-0');
+
+    // Add a single note, then select it (the only event in the measure).
+    fireEvent.mouseMove(hitArea, { clientX: 50, clientY: 110 });
+    await screen.findByTestId('ghost-note');
+    fireEvent.click(hitArea, { clientX: 50, clientY: 110 });
+
+    const noteGroup = screen.getAllByTestId(/^chord-[^t]/)[0];
+    fireEvent.click(noteGroup);
+    await waitFor(() => expect(noteGroup).toHaveAttribute('data-selected', 'true'));
+
+    const container = screen.getByTestId('score-canvas-container');
+    fireEvent.focus(container);
+    fireEvent.mouseEnter(container);
+
+    // Delete → measure empties, selection clears to null.
+    fireEvent.keyDown(window, { key: 'Backspace', code: 'Backspace', keyCode: 8 });
+    await waitFor(() => {
+      expect(screen.queryAllByTestId(/^chord-[^t]/)).toHaveLength(0);
+    });
+
+    // Undo (Cmd+Z) → the event is restored AND re-selected (#257). Without the fix the restored
+    // chord would render unselected (data-selected !== 'true').
+    fireEvent.keyDown(window, { key: 'z', code: 'KeyZ', metaKey: true });
+    await waitFor(() => {
+      const restored = screen.queryAllByTestId(/^chord-[^t]/);
+      expect(restored).toHaveLength(1);
+      expect(restored[0]).toHaveAttribute('data-selected', 'true');
+    });
+  });
+
   test('Cursor auto-advances after APPENDing a note', async () => {
     const score = createDefaultScore();
     render(

--- a/src/__tests__/SelectionEngine.test.ts
+++ b/src/__tests__/SelectionEngine.test.ts
@@ -186,4 +186,37 @@ describe('SelectionEngine', () => {
       expect(engine.getState().eventId).toBe('event-1');
     });
   });
+
+  // #257: a delete that empties the selection stashes its pre-delete coord here; the next undo that
+  // re-materializes it re-selects it. The engine is dumb storage — the resolve check lives in the
+  // useScoreLogic restore effect.
+  describe('pending restore stash (#257)', () => {
+    const coord = { staffIndex: 0, measureIndex: 1, eventId: 'e1', noteId: 'n1' };
+
+    test('starts empty', () => {
+      engine = new SelectionEngine();
+      expect(engine.getPendingRestore()).toBeNull();
+    });
+
+    test('stash then get returns the coord', () => {
+      engine = new SelectionEngine();
+      engine.stashPendingRestore(coord);
+      expect(engine.getPendingRestore()).toEqual(coord);
+    });
+
+    test('clear drops the coord', () => {
+      engine = new SelectionEngine();
+      engine.stashPendingRestore(coord);
+      engine.clearPendingRestore();
+      expect(engine.getPendingRestore()).toBeNull();
+    });
+
+    test('stash is single-slot (last write wins)', () => {
+      engine = new SelectionEngine();
+      engine.stashPendingRestore(coord);
+      const coord2 = { staffIndex: 1, measureIndex: 2, eventId: 'e2', noteId: null };
+      engine.stashPendingRestore(coord2);
+      expect(engine.getPendingRestore()).toEqual(coord2);
+    });
+  });
 });

--- a/src/__tests__/TimelineService.test.ts
+++ b/src/__tests__/TimelineService.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { createTimeline } from '@/services/TimelineService';
-import type { Score } from '@/types';
+import type { Score, ScoreEvent } from '@/types';
 
 describe('TimelineService', () => {
   const mockScore: Score = {
@@ -300,5 +300,152 @@ describe('TimelineService', () => {
     expect(timeline[1].quant).toBe(16);
     expect(timeline[2].quant).toBe(32);
     expect(timeline[3].quant).toBe(48);
+  });
+
+  // #261 — probe the playback lane against the tuplet / tie / reflow features the editor now supports.
+  // Tie connectivity routes through the SSOT (`findTieTarget`), so these lock the contract that
+  // playback can never disagree with render/export about what a tie connects to.
+  describe('#261 tuplets / ties / reflow', () => {
+    test('breaks a tie when the immediate next event is a rest (a rest is never a tie target)', () => {
+      const score: Score = {
+        ...mockScore,
+        staves: [
+          {
+            id: 'staff-1',
+            clef: 'treble' as const,
+            keySignature: 'C',
+            measures: [
+              {
+                id: '1',
+                events: [
+                  // C4 quarter, authored as tied...
+                  {
+                    id: 'e1',
+                    duration: 'quarter',
+                    dotted: false,
+                    notes: [{ id: 'n1', pitch: 'C4', tied: true }],
+                  },
+                  // ...but the immediate next event is a rest — the tie must NOT connect across it.
+                  {
+                    id: 'e2',
+                    duration: 'quarter',
+                    dotted: false,
+                    isRest: true,
+                    notes: [{ id: 'n2', pitch: null, isRest: true }],
+                  },
+                  // A later same-pitch C4 is a separate sound, never merged into the first.
+                  {
+                    id: 'e3',
+                    duration: 'quarter',
+                    dotted: false,
+                    notes: [{ id: 'n3', pitch: 'C4', tied: false }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const timeline = createTimeline(score, 60); // 1 beat = 1s
+      const c4 = timeline.filter((e) => e.pitch === 'C4');
+      expect(c4).toHaveLength(2);
+      expect(c4[0].time).toBeCloseTo(0);
+      expect(c4[0].duration).toBeCloseTo(1.0); // NOT merged into a 2s note
+      expect(c4[1].time).toBeCloseTo(2.0);
+      expect(c4[1].duration).toBeCloseTo(1.0);
+    });
+
+    test('merges a tie between two members of the same tuplet group', () => {
+      const trip = (id: string, pitch: string, tied: boolean): ScoreEvent => ({
+        id,
+        duration: 'quarter',
+        dotted: false,
+        tuplet: { ratio: [3, 2], groupSize: 3, position: 0, baseDuration: 'quarter', id: 'T' },
+        notes: [{ id: `${id}n`, pitch, tied }],
+      });
+      const score: Score = {
+        ...mockScore,
+        staves: [
+          {
+            id: 'staff-1',
+            clef: 'treble' as const,
+            keySignature: 'C',
+            measures: [{ id: '1', events: [trip('e1', 'C4', true), trip('e2', 'C4', false), trip('e3', 'E4', false)] }],
+          },
+        ],
+      };
+
+      const timeline = createTimeline(score, 120);
+      // quarter-triplet member = 16 * 2/3 quants; secondsPerQuant @120bpm = (60/120)/16 = 0.03125.
+      const memberSeconds = ((16 * 2) / 3) * 0.03125;
+      const c4 = timeline.filter((e) => e.pitch === 'C4');
+      expect(c4).toHaveLength(1);
+      expect(c4[0].duration).toBeCloseTo(memberSeconds * 2, 5); // two members merged
+      const e4 = timeline.filter((e) => e.pitch === 'E4');
+      expect(e4).toHaveLength(1);
+      expect(e4[0].duration).toBeCloseTo(memberSeconds, 5);
+    });
+
+    test('cross-barline tie out of an under-full bar merges to the tied-to note grid end (SSOT, not adjacency)', () => {
+      // The discriminator between the SSOT routing and the old float time-adjacency merge: a tied C4
+      // as the LAST event of an under-full 4/4 bar (it does not fill the bar) ties across the barline
+      // to a same-pitch C4 at the start of the next bar. The old adjacency code saw a 3s gap (bar 2
+      // starts at 4s, the tied note ends at 1s) and refused to merge; findTieTarget crosses the
+      // barline by event adjacency and merges. The merged span runs to the tied-to note's grid end.
+      const score: Score = {
+        ...mockScore,
+        timeSignature: '4/4',
+        staves: [
+          {
+            id: 'staff-1',
+            clef: 'treble' as const,
+            keySignature: 'C',
+            measures: [
+              { id: 'm1', events: [{ id: 'e1', duration: 'quarter', dotted: false, notes: [{ id: 'n1', pitch: 'C4', tied: true }] }] },
+              { id: 'm2', events: [{ id: 'e2', duration: 'quarter', dotted: false, notes: [{ id: 'n2', pitch: 'C4', tied: false }] }] },
+            ],
+          },
+        ],
+      };
+
+      const timeline = createTimeline(score, 60); // 1 beat = 1s; 4/4 bar = 4s
+      const c4 = timeline.filter((e) => e.pitch === 'C4');
+      expect(c4).toHaveLength(1); // merged across the barline via the SSOT
+      expect(c4[0].time).toBeCloseTo(0);
+      // Span runs to bar 2's note end (5s), NOT a naive 1+1=2s — the under-full gap doesn't collapse.
+      expect(c4[0].duration).toBeCloseTo(5.0);
+    });
+
+    test('places bars on a meter-aware grid, not a hardcoded 4/4 one (reflow dimension)', () => {
+      // Two full 3/4 bars: the second bar must start at 3 beats, proving the timeline tracks the
+      // re-barred meter (#254) rather than assuming a 4/4 bar length.
+      const bar = (id: string, p1: string, p2: string, p3: string) => ({
+        id,
+        events: [p1, p2, p3].map((pitch, i) => ({
+          id: `${id}e${i}`,
+          duration: 'quarter',
+          dotted: false,
+          notes: [{ id: `${id}n${i}`, pitch }],
+        })),
+      });
+      const score: Score = {
+        ...mockScore,
+        timeSignature: '3/4',
+        staves: [
+          {
+            id: 'staff-1',
+            clef: 'treble' as const,
+            keySignature: 'C',
+            measures: [bar('m1', 'C4', 'D4', 'E4'), bar('m2', 'F4', 'G4', 'A4')],
+          },
+        ],
+      };
+
+      const timeline = createTimeline(score, 60); // 1 beat = 1s
+      const f4 = timeline.find((e) => e.pitch === 'F4'); // first note of bar 2
+      expect(f4).toBeDefined();
+      expect(f4!.time).toBeCloseTo(3.0); // 3/4 bar => bar 2 at 3s, not 4s
+    });
   });
 });

--- a/src/__tests__/hooks/note/appendPastFullBar.test.tsx
+++ b/src/__tests__/hooks/note/appendPastFullBar.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * #263 — Keyboard Enter must not lose the note when appending past the end of a FULL last bar.
+ *
+ * A hover/keyboard APPEND ghost past the end of a full last bar targets `measureIndex + 1` — a bar
+ * that does not exist yet. Committing (Enter passes shouldAutoAdvance=true) used to dispatch a plain
+ * AddEventCommand against that non-existent measure, which silently no-ops in the engine → the note
+ * was lost (mouse click worked, because its capacity-fail path auto-creates the bar — an
+ * Enter-vs-click divergence). The fix gives `addNoteToMeasure` a phantom-target guard that creates
+ * the bar first, then places into it — and is gated on shouldAutoAdvance so the existing
+ * auto-advance RECURSION (which re-enters with an out-of-range index and shouldAutoAdvance=false) is
+ * untouched and cannot double-create or loop.
+ *
+ * @see src/hooks/note/useNoteEntry.ts
+ */
+jest.mock('@/engines/toneEngine', () => ({
+  playNote: jest.fn(),
+  setInstrument: jest.fn(),
+  isSamplerLoaded: jest.fn(() => false),
+  InstrumentType: {},
+}));
+
+import { renderHook, act } from '@testing-library/react';
+import { RefObject } from 'react';
+import { useNoteEntry } from '@/hooks/note/useNoteEntry';
+import { AddMeasureCommand } from '@/commands/MeasureCommands';
+import { AddEventCommand } from '@/commands/AddEventCommand';
+import { createDefaultScore, createDefaultSelection, Score, Selection } from '@/types';
+
+// One full 4/4 bar (a whole note = 64 quants), so an append ghost past it targets phantom index 1.
+const fullBarScore = (): Score => {
+  const s = createDefaultScore();
+  s.timeSignature = '4/4';
+  s.staves = [
+    {
+      ...s.staves[0],
+      measures: [
+        { id: 'm0', events: [{ id: 'w', duration: 'whole', dotted: false, notes: [{ id: 'wn', pitch: 'C4' }] }] },
+      ],
+    },
+  ];
+  return s;
+};
+
+const props = (score: Score, dispatch: jest.Mock, selectionOver: Partial<Selection> = {}) => ({
+  scoreRef: { current: score } as RefObject<Score>,
+  selection: { ...createDefaultSelection(), measureIndex: 0, staffIndex: 0, ...selectionOver } as Selection,
+  select: jest.fn(),
+  setPreviewNote: jest.fn(),
+  activeDuration: 'quarter',
+  isDotted: false,
+  activeAccidental: null,
+  activeTie: false,
+  currentQuantsPerMeasure: 64,
+  dispatch,
+  inputMode: 'NOTE' as const,
+});
+
+describe('#263 append past a full last bar', () => {
+  it('Enter on the phantom append ghost creates the bar AND places the note', () => {
+    const dispatch = jest.fn();
+    const { result } = renderHook(() =>
+      useNoteEntry(props(fullBarScore(), dispatch, { eventId: 'w', noteId: 'wn' }))
+    );
+
+    // The append ghost past the full last bar targets measureIndex 1 (phantom); Enter commits with
+    // shouldAutoAdvance=true. Before the fix: only AddEventCommand(1) → no-op against a missing bar.
+    act(() => {
+      result.current.addNoteToMeasure(1, { pitch: 'D4', mode: 'APPEND', index: 0 }, true);
+    });
+
+    const dispatched = dispatch.mock.calls.map((c) => c[0]);
+    // The bar is created first, then the note is placed into it.
+    expect(dispatched[0]).toBeInstanceOf(AddMeasureCommand);
+    expect(dispatched.some((c) => c instanceof AddEventCommand)).toBe(true);
+  });
+
+  it('does NOT auto-create for a phantom index when shouldAutoAdvance is false (recursion-safe gating)', () => {
+    // The auto-advance recursion re-enters with an out-of-range index and shouldAutoAdvance=false,
+    // relying on the freshly-dispatched engine measure. That path must fall through to a normal
+    // dispatch — never re-trigger the create guard (which would double-create / loop).
+    const dispatch = jest.fn();
+    const { result } = renderHook(() =>
+      useNoteEntry(props(fullBarScore(), dispatch, { eventId: 'w', noteId: 'wn' }))
+    );
+
+    act(() => {
+      result.current.addNoteToMeasure(1, { pitch: 'D4', mode: 'APPEND', index: 0 }, false);
+    });
+
+    const dispatched = dispatch.mock.calls.map((c) => c[0]);
+    expect(dispatched.some((c) => c instanceof AddMeasureCommand)).toBe(false);
+    // It still attempts the (engine-resolved) event dispatch, exactly as the recursion does today.
+    expect(dispatched.some((c) => c instanceof AddEventCommand)).toBe(true);
+  });
+});

--- a/src/__tests__/hooks/note/useNoteDelete.test.tsx
+++ b/src/__tests__/hooks/note/useNoteDelete.test.tsx
@@ -30,7 +30,6 @@ const ev = (id: string, pitches: string[]): ScoreEvent => ({
 describe('useNoteDelete', () => {
   let mockDispatch: jest.Mock;
   let mockSelect: jest.Mock;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockSelectionEngine: any;
 
   beforeEach(() => {

--- a/src/__tests__/hooks/note/useNoteDelete.test.tsx
+++ b/src/__tests__/hooks/note/useNoteDelete.test.tsx
@@ -30,10 +30,17 @@ const ev = (id: string, pitches: string[]): ScoreEvent => ({
 describe('useNoteDelete', () => {
   let mockDispatch: jest.Mock;
   let mockSelect: jest.Mock;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockSelectionEngine: any;
 
   beforeEach(() => {
     mockDispatch = jest.fn();
     mockSelect = jest.fn();
+    mockSelectionEngine = {
+      stashPendingRestore: jest.fn(),
+      getPendingRestore: jest.fn(() => null),
+      clearPendingRestore: jest.fn(),
+    };
     jest.clearAllMocks();
   });
 
@@ -49,7 +56,7 @@ describe('useNoteDelete', () => {
       };
 
       const { result } = renderHook(() =>
-        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, scoreRef: emptyRef() })
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef: emptyRef() })
       );
 
       act(() => {
@@ -61,6 +68,51 @@ describe('useNoteDelete', () => {
       expect(mockSelect).toHaveBeenCalledWith(null, null, null, 0);
     });
 
+    it('stashes for a single-note (click) selection so undo can re-anchor (#257)', () => {
+      // A click populates selectedNotes with ONE entry == the primary, so the delete routes here.
+      const selection: Selection = {
+        ...createDefaultSelection(),
+        measureIndex: 0,
+        eventId: 'e1',
+        noteId: 'n1',
+        staffIndex: 0,
+        selectedNotes: [{ staffIndex: 0, measureIndex: 0, eventId: 'e1', noteId: 'n1' }],
+      };
+
+      const { result } = renderHook(() =>
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef: emptyRef() })
+      );
+      act(() => result.current.deleteSelected());
+
+      expect(mockSelectionEngine.stashPendingRestore).toHaveBeenCalledWith({
+        staffIndex: 0,
+        measureIndex: 0,
+        eventId: 'e1',
+        noteId: 'n1',
+      });
+    });
+
+    it('does NOT stash for a true multi-note (>1) selection — one undo only restores the last (#257)', () => {
+      const selection: Selection = {
+        ...createDefaultSelection(),
+        measureIndex: 0,
+        eventId: 'e1',
+        noteId: 'n1',
+        staffIndex: 0,
+        selectedNotes: [
+          { staffIndex: 0, measureIndex: 0, eventId: 'e1', noteId: 'n1' },
+          { staffIndex: 0, measureIndex: 0, eventId: 'e2', noteId: 'n2' },
+        ],
+      };
+
+      const { result } = renderHook(() =>
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef: emptyRef() })
+      );
+      act(() => result.current.deleteSelected());
+
+      expect(mockSelectionEngine.stashPendingRestore).not.toHaveBeenCalled();
+    });
+
     it('deletes events when noteId is missing in selectedNotes', () => {
       const selection: Selection = {
         ...createDefaultSelection(),
@@ -68,7 +120,7 @@ describe('useNoteDelete', () => {
       };
 
       const { result } = renderHook(() =>
-        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, scoreRef: emptyRef() })
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef: emptyRef() })
       );
 
       act(() => {
@@ -92,7 +144,7 @@ describe('useNoteDelete', () => {
       };
 
       const { result } = renderHook(() =>
-        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, scoreRef: emptyRef() })
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef: emptyRef() })
       );
 
       act(() => {
@@ -114,7 +166,7 @@ describe('useNoteDelete', () => {
       };
 
       const { result } = renderHook(() =>
-        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, scoreRef: emptyRef() })
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef: emptyRef() })
       );
 
       act(() => {
@@ -139,7 +191,7 @@ describe('useNoteDelete', () => {
       const scoreRef = refTo(scoreWith([ev('e1', ['C4']), ev('e2', ['D4'])]));
 
       const { result } = renderHook(() =>
-        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, scoreRef })
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef })
       );
       act(() => result.current.deleteSelected());
 
@@ -158,7 +210,7 @@ describe('useNoteDelete', () => {
       const scoreRef = refTo(scoreWith([ev('e1', ['C4']), ev('e2', ['D4'])]));
 
       const { result } = renderHook(() =>
-        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, scoreRef })
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef })
       );
       act(() => result.current.deleteSelected());
 
@@ -177,14 +229,14 @@ describe('useNoteDelete', () => {
       const scoreRef = refTo(scoreWith([ev('e1', ['C4', 'E4', 'G4'])]));
 
       const { result } = renderHook(() =>
-        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, scoreRef })
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef })
       );
       act(() => result.current.deleteSelected());
 
       expect(mockSelect).toHaveBeenCalledWith(0, 'e1', 'e1n1', 0);
     });
 
-    it('clears the selection when deleting the only event in the measure', () => {
+    it('clears the selection AND stashes the pre-delete coord when deleting the only event (#257)', () => {
       const selection: Selection = {
         ...createDefaultSelection(),
         measureIndex: 0,
@@ -196,11 +248,37 @@ describe('useNoteDelete', () => {
       const scoreRef = refTo(scoreWith([ev('e1', ['C4'])]));
 
       const { result } = renderHook(() =>
-        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, scoreRef })
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef })
       );
       act(() => result.current.deleteSelected());
 
       expect(mockSelect).toHaveBeenCalledWith(null, null, null, 0);
+      // #257: the cleared coord is stashed so a later undo can re-select the restored event.
+      expect(mockSelectionEngine.stashPendingRestore).toHaveBeenCalledWith({
+        staffIndex: 0,
+        measureIndex: 0,
+        eventId: 'e1',
+        noteId: 'e1n0',
+      });
+    });
+
+    it('does NOT stash when the delete re-anchors to a surviving neighbor (#257)', () => {
+      const selection: Selection = {
+        ...createDefaultSelection(),
+        measureIndex: 0,
+        eventId: 'e1',
+        noteId: 'e1n0',
+        staffIndex: 0,
+        selectedNotes: [],
+      };
+      const scoreRef = refTo(scoreWith([ev('e1', ['C4']), ev('e2', ['D4'])]));
+
+      const { result } = renderHook(() =>
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef })
+      );
+      act(() => result.current.deleteSelected());
+
+      expect(mockSelectionEngine.stashPendingRestore).not.toHaveBeenCalled();
     });
   });
 
@@ -214,7 +292,7 @@ describe('useNoteDelete', () => {
       };
 
       const { result } = renderHook(() =>
-        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, scoreRef: emptyRef() })
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef: emptyRef() })
       );
 
       act(() => {
@@ -234,7 +312,7 @@ describe('useNoteDelete', () => {
       };
 
       const { result } = renderHook(() =>
-        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, scoreRef: emptyRef() })
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef: emptyRef() })
       );
 
       act(() => {

--- a/src/__tests__/navigationHelpers.test.ts
+++ b/src/__tests__/navigationHelpers.test.ts
@@ -14,6 +14,7 @@ import {
   selectNoteInEventByDirection,
   getAdjustedDuration,
   calculateVerticalNavigation,
+  calculateCrossStaffSelection,
 } from '@/utils/interaction';
 
 describe('Navigation Helper Functions', () => {
@@ -271,6 +272,113 @@ describe('calculateVerticalNavigation', () => {
       expect(result?.selection?.eventId).toBeNull();
       expect(result?.previewNote).toBeDefined();
       expect(result?.previewNote?.staffIndex).toBe(1);
+    });
+  });
+
+  // #264 — cross-staff nav into an incomplete tuplet's free (reserved) space must surface a
+  // tuplet-fill ghost (parity with horizontal #6), not land on a blank reserved slot or jump to
+  // events[0]. Bass has a quarter-triplet [C3, E3, reserved]: members occupy quants 0–10.67,
+  // 10.67–21.33, and the reserved free space is [21.33, 32). The treble source's 3rd event starts at
+  // quant 24, which aligns into that free space.
+  describe('#264 cross-staff tuplet-fill ghost', () => {
+    const trip = (id: string, pitch: string | null, position: number, reserved = false) => ({
+      id,
+      duration: 'quarter',
+      dotted: false,
+      isRest: reserved,
+      reserved,
+      notes: reserved ? [{ id: `${id}n`, pitch: null, isRest: true }] : [{ id: `${id}n`, pitch }],
+      tuplet: { ratio: [3, 2] as [number, number], groupSize: 3, position, baseDuration: 'quarter', id: 'BT' },
+    });
+    const bassTupletStaff = {
+      id: 'bass-tuplet',
+      clef: 'bass' as const,
+      keySignature: 'C',
+      measures: [
+        { id: 'mb', events: [trip('bt0', 'C3', 0), trip('bt1', 'E3', 1), trip('btr', null, 2, true)] },
+      ],
+    };
+    // 3rd event ('st2') starts at quant 24 (16 + 8), inside the bass tuplet's reserved free space.
+    const sourceTrebleStaff = {
+      id: 'treble-src',
+      clef: 'treble' as const,
+      keySignature: 'C',
+      measures: [
+        {
+          id: 'mt',
+          events: [
+            { id: 'st0', duration: 'quarter', dotted: false, notes: [{ id: 'st0n', pitch: 'C5' }] },
+            { id: 'st1', duration: 'eighth', dotted: false, notes: [{ id: 'st1n', pitch: 'D5' }] },
+            { id: 'st2', duration: 'quarter', dotted: false, notes: [{ id: 'st2n', pitch: 'E5' }] },
+          ],
+        },
+      ],
+    };
+
+    test('calculateCrossStaffSelection returns a fill ghost when the aligned quant is in tuplet free space', () => {
+      const score = createScore([sourceTrebleStaff, bassTupletStaff]);
+      const selection = { staffIndex: 0, measureIndex: 0, eventId: 'st2', noteId: 'st2n' };
+
+      const result = calculateCrossStaffSelection(score, selection, 'down', 'quarter', false);
+
+      expect(result?.selection?.staffIndex).toBe(1);
+      expect(result?.selection?.eventId).toBeNull(); // a ghost, not a landed event
+      expect(result?.selection?.measureIndex).toBeNull();
+      expect(result?.previewNote?.mode).toBe('CHORD');
+      expect(result?.previewNote?.eventId).toBe('btr'); // anchored to the reserved slot
+    });
+
+    test('calculateVerticalNavigation (selected note) returns a fill ghost, not events[0]', () => {
+      const score = createScore([sourceTrebleStaff, bassTupletStaff]);
+      const selection = { staffIndex: 0, measureIndex: 0, eventId: 'st2', noteId: 'st2n' };
+
+      const result = calculateVerticalNavigation(score, selection, 'down', 'quarter', false, null);
+
+      expect(result?.selection?.eventId).toBeNull();
+      expect(result?.previewNote?.mode).toBe('CHORD');
+      expect(result?.previewNote?.eventId).toBe('btr');
+    });
+
+    test('staff-cycle wrap (Cmd+Down from the last staff) into tuplet free space returns a fill ghost, not a blank slot', () => {
+      // The tuplet is on the TOP staff; the source note is on the BOTTOM staff. Cmd+Down from the
+      // bottom staff has no lower staff, so it WRAPS (cycles) to the top staff. That cycle path uses
+      // findEventAtQuantPosition (not reserved-aware), so without the fix it would LAND on the blank
+      // reserved slot — the exact thing #264 prevents. It must return a fill ghost instead.
+      const topTuplet = { ...bassTupletStaff, id: 'top-tuplet', clef: 'treble' as const };
+      const bottomSource = { ...sourceTrebleStaff, id: 'bottom-src', clef: 'bass' as const };
+      const score = createScore([topTuplet, bottomSource]);
+      const selection = { staffIndex: 1, measureIndex: 0, eventId: 'st2', noteId: 'st2n' };
+
+      const result = calculateVerticalNavigation(score, selection, 'down', 'quarter', false, null);
+
+      expect(result?.selection?.staffIndex).toBe(0);
+      expect(result?.selection?.eventId).toBeNull(); // a ghost, never the blank reserved slot
+      expect(result?.previewNote?.mode).toBe('CHORD');
+      expect(result?.previewNote?.eventId).toBe('btr');
+    });
+
+    test('calculateVerticalNavigation (ghost cursor) returns a fill ghost, not events[0]', () => {
+      const score = createScore([sourceTrebleStaff, bassTupletStaff]);
+      const selection = { staffIndex: 0, measureIndex: null, eventId: null, noteId: null };
+      const previewNote = {
+        measureIndex: 0,
+        staffIndex: 0,
+        quant: 24, // aligns into the bass tuplet's reserved free space
+        visualQuant: 24,
+        pitch: 'E5',
+        duration: 'quarter',
+        dotted: false,
+        mode: 'APPEND' as const,
+        index: 2,
+        isRest: false,
+      };
+
+      const result = calculateVerticalNavigation(score, selection, 'down', 'quarter', false, previewNote);
+
+      // Before the fix this selected bt0 (events[0]); now it's a fill ghost anchored to the slot.
+      expect(result?.selection?.eventId).toBeNull();
+      expect(result?.previewNote?.mode).toBe('CHORD');
+      expect(result?.previewNote?.eventId).toBe('btr');
     });
   });
 

--- a/src/engines/SelectionEngine.ts
+++ b/src/engines/SelectionEngine.ts
@@ -16,6 +16,7 @@ import type { Selection, Score } from '../types';
 import { createDefaultSelection } from '../types';
 import type { SelectionCommand } from '../commands/selection/types';
 import { SetSelectionCommand } from '../commands/selection/SetSelectionCommand';
+import type { TargetCoord } from '../utils/selectionRepair';
 
 type SelectionListener = (selection: Selection) => void;
 
@@ -23,6 +24,14 @@ export class SelectionEngine {
   private state: Selection;
   private listeners: Set<SelectionListener> = new Set();
   private scoreRef: () => Score;
+  /**
+   * A selection coordinate cleared by a delete that emptied the selection (no surviving neighbor),
+   * held so the next undo that re-materializes it can re-select it (#257). Selection lives OUTSIDE
+   * undo history by design, so the engine remembers this one coordinate rather than snapshotting the
+   * whole selection per command. EventIds are unique, so this only resolves by undoing that exact
+   * delete — it can't fire spuriously on an unrelated edit.
+   */
+  private pendingRestore: TargetCoord | null = null;
 
   /**
    * Create a SelectionEngine
@@ -125,6 +134,24 @@ export class SelectionEngine {
         })
       );
     }
+  }
+
+  /**
+   * Stash a coordinate to re-select if a later undo restores it (#257). Overwrites any prior stash
+   * (single-slot, last-delete-wins).
+   */
+  public stashPendingRestore(coord: TargetCoord): void {
+    this.pendingRestore = coord;
+  }
+
+  /** The pending re-select coordinate, or null. */
+  public getPendingRestore(): TargetCoord | null {
+    return this.pendingRestore;
+  }
+
+  /** Drop the pending re-select coordinate (after it's been honored, or is no longer wanted). */
+  public clearPendingRestore(): void {
+    this.pendingRestore = null;
   }
 
   private notifyListeners(): void {

--- a/src/hooks/api/io.ts
+++ b/src/hooks/api/io.ts
@@ -46,6 +46,9 @@ export const createIOMethods = (
       }
 
       dispatch(new LoadScoreCommand(newScore));
+      // A wholesale replace invalidates any pending undo-restore stash — its coord belongs to the
+      // old score, and a loaded score may reuse authored ids that would spuriously resolve (#257).
+      ctx.selectionEngine.clearPendingRestore();
 
       // Surface content-validity problems (over-full / incomplete-tuplet bars, grand-staff parity)
       // as a NON-blocking warning: the score still loads (so it can be fixed) but the caller is told.
@@ -86,6 +89,7 @@ export const createIOMethods = (
       };
 
       dispatch(new LoadScoreCommand(newScore));
+      ctx.selectionEngine.clearPendingRestore(); // wholesale replace invalidates the stash (#257)
       setResult({
         ok: true,
         status: 'info',

--- a/src/hooks/note/useNoteActions.ts
+++ b/src/hooks/note/useNoteActions.ts
@@ -36,6 +36,7 @@ import { useNoteDelete } from './useNoteDelete';
 import { useNotePitch } from './useNotePitch';
 import { PreviewNote } from '@/utils/entry';
 import { HitZone } from '@/engines/layout/types';
+import type { SelectionEngine } from '@/engines/SelectionEngine';
 
 /**
  * Props for the useNoteActions composition hook.
@@ -86,6 +87,9 @@ export interface UseNoteActionsProps {
 
   /** Current input mode (NOTE or REST) */
   inputMode: InputMode;
+
+  /** Selection engine — used by delete to stash a pre-delete coord for undo re-anchoring (#257) */
+  selectionEngine: SelectionEngine;
 }
 
 /**
@@ -222,6 +226,7 @@ export const useNoteActions = ({
   currentQuantsPerMeasure,
   dispatch,
   inputMode,
+  selectionEngine,
 }: UseNoteActionsProps): UseNoteActionsReturn => {
   // --- READ: Hover preview for ghost note display ---
   const { handleMeasureHover } = useHoverPreview({
@@ -255,6 +260,7 @@ export const useNoteActions = ({
     select,
     dispatch,
     scoreRef,
+    selectionEngine,
   });
 
   // --- UPDATE: Pitch modification ---

--- a/src/hooks/note/useNoteDelete.ts
+++ b/src/hooks/note/useNoteDelete.ts
@@ -3,6 +3,7 @@ import { Score, Selection, getValidStaff } from '@/types';
 import { Command } from '@/commands/types';
 import { DeleteNoteCommand } from '@/commands/DeleteNoteCommand';
 import { DeleteEventCommand } from '@/commands/DeleteEventCommand';
+import type { SelectionEngine } from '@/engines/SelectionEngine';
 
 /**
  * Props for the useNoteDelete hook.
@@ -21,6 +22,8 @@ export interface UseNoteDeleteProps {
   dispatch: (command: Command) => void;
   /** Live score ref — used to pick the post-delete re-anchor target (#242 Lane G) */
   scoreRef: RefObject<Score>;
+  /** Selection engine — stashes the pre-delete coord when a delete empties the selection (#257) */
+  selectionEngine: SelectionEngine;
 }
 
 /**
@@ -61,8 +64,25 @@ export function useNoteDelete({
   select,
   dispatch,
   scoreRef,
+  selectionEngine,
 }: UseNoteDeleteProps): UseNoteDeleteReturn {
   const deleteSelected = useCallback(() => {
+    // Stash the pre-delete primary coord before clearing the selection to null (#257), so the next
+    // undo that re-materializes that exact event/note (ids are stable across undo) re-selects it —
+    // the Lane G repair effect only prunes, never re-anchors. EventIds are unique, so the stash can
+    // only resolve by undoing this delete; it can't fire on an unrelated edit. Used by both the
+    // multi-selection clear and the single no-neighbor clear below.
+    const stashClearedSelection = () => {
+      if (selection.measureIndex !== null && selection.eventId) {
+        selectionEngine.stashPendingRestore({
+          staffIndex: selection.staffIndex,
+          measureIndex: selection.measureIndex,
+          eventId: selection.eventId,
+          noteId: selection.noteId,
+        });
+      }
+    };
+
     // 1. Delete Multi-Selection
     if (selection.selectedNotes && selection.selectedNotes.length > 0) {
       const notesToDelete = [...selection.selectedNotes];
@@ -76,7 +96,12 @@ export function useNoteDelete({
           dispatch(new DeleteEventCommand(note.measureIndex, note.eventId, note.staffIndex));
         }
       });
-      // Clear selection after delete
+      // Clear selection after delete. Only stash for a single-note selection (a click populates
+      // selectedNotes with one entry == the primary): a true multi-note delete dispatches N separate
+      // history entries, so one undo restores only the last and a primary-coord stash would re-select
+      // partially or mis-fire on a later undo (#257 review). Re-anchoring a multi-delete undo is out
+      // of #257 scope — leave it unstashed.
+      if (notesToDelete.length === 1) stashClearedSelection();
       select(null, null, null, selection.staffIndex);
       return;
     }
@@ -127,11 +152,13 @@ export function useNoteDelete({
     }
 
     if (reanchorEventId === null) {
+      // No surviving neighbor — the selection clears to null. Stash so an undo re-selects it (#257).
+      stashClearedSelection();
       select(null, null, null, selection.staffIndex);
     } else {
       select(selection.measureIndex, reanchorEventId, reanchorNoteId, selection.staffIndex);
     }
-  }, [selection, dispatch, select, scoreRef]);
+  }, [selection, dispatch, select, scoreRef, selectionEngine]);
 
   return { deleteSelected };
 }

--- a/src/hooks/note/useNoteEntry.ts
+++ b/src/hooks/note/useNoteEntry.ts
@@ -176,6 +176,32 @@ export function useNoteEntry({
         newNote.staffIndex !== undefined ? newNote.staffIndex : selection.staffIndex;
       const currentStaffData = getActiveStaff(currentScore, currentStaffIndex);
 
+      // (#263) Phantom target past the last existing bar. A hover/keyboard APPEND ghost past the end
+      // of a FULL last bar targets `measureIndex + 1` — a bar that doesn't exist yet. Committing a
+      // plain AddEventCommand there silently no-ops against the missing measure (the note is lost),
+      // because the phantom's empty event list passes the capacity check below and never reaches the
+      // capacity-fail auto-advance path. Create the bar first, then place into it.
+      //
+      // Reached by the keyboard Enter commit, whose preview targets the phantom `measureIndex + 1`
+      // bar (useHoverPreview). The mouse-click path also passes shouldAutoAdvance=true but commits
+      // against the in-bounds last-bar index (useMeasureInteraction), so it instead takes the
+      // capacity-fail auto-advance branch below. Gated on `shouldAutoAdvance` so it does NOT fire for
+      // the auto-advance RECURSION, which intentionally re-enters with `shouldAutoAdvance = false` and
+      // an out-of-range index that resolves against the freshly dispatched engine measure (scoreRef
+      // is still stale on that synchronous re-entry) — that path must fall through to the normal
+      // dispatch. Running before the tuplet/slot branches also means a stale selection on a tuplet
+      // member can't be overwritten.
+      if (measureIndex >= currentStaffData.measures.length && shouldAutoAdvance) {
+        dispatch(new AddMeasureCommand());
+        addNoteToMeasureCallback(
+          measureIndex,
+          { ...newNote, staffIndex: currentStaffIndex },
+          false,
+          { mode: 'APPEND', index: 0 }
+        );
+        return;
+      }
+
       const newMeasures = [...currentStaffData.measures];
       const targetMeasure = { ...newMeasures[measureIndex] };
       if (!targetMeasure.events) targetMeasure.events = [];

--- a/src/hooks/useScoreLogic.ts
+++ b/src/hooks/useScoreLogic.ts
@@ -29,7 +29,7 @@ import { useTupletActions } from './useTupletActions';
 
 import { createDefaultScore, migrateScore, PreviewNote, Score } from '@/types';
 import type { RefusalSeverity } from '@/refusals';
-import { repairSelection } from '@/utils/selectionRepair';
+import { repairSelection, resolveTarget } from '@/utils/selectionRepair';
 
 // Extracted score modules
 import { useDerivedSelection } from './score/useDerivedSelection';
@@ -169,6 +169,37 @@ export const useScoreLogic = (initialScore?: Partial<Score>) => {
     if (repaired !== current) selectionEngine.setState(repaired);
   }, [score, selectionEngine]);
 
+  // #257: a delete that emptied the selection stashed its pre-delete coord. When a later undo
+  // re-materializes that exact event (ids are stable across undo), re-select it — the repair effect
+  // above only prunes, never re-anchors, so without this the restored event sits unselected. Keyed on
+  // `score` like the repair effect; runs after the prune so it sets the final, live coordinate.
+  //
+  // Only honor the stash while the selection is STILL empty (the delete left it so): if the user
+  // deliberately selected something in the meantime, don't clobber it — and a fresh single selection
+  // is built (primary + selectedNotes + anchor all on the restored note) so the state stays coherent
+  // rather than a primary that disagrees with a stale selectedNotes/anchor (#257 review).
+  useEffect(() => {
+    const pending = selectionEngine.getPendingRestore();
+    if (!pending) return;
+    const current = selectionEngine.getState();
+    if (current.eventId !== null) return; // user moved on — leave their selection alone
+    if (!resolveTarget(score, pending).ok) return; // not yet re-materialized (or never will be)
+
+    const coord = {
+      staffIndex: pending.staffIndex,
+      measureIndex: pending.measureIndex,
+      eventId: pending.eventId,
+      noteId: pending.noteId,
+    };
+    selectionEngine.setState({
+      ...current,
+      ...coord,
+      selectedNotes: [coord],
+      anchor: coord,
+    });
+    selectionEngine.clearPendingRestore();
+  }, [score, selectionEngine]);
+
   // --- COMPUTED VALUES ---
   // Fail-fast: throw for Error Boundary instead of logging and continuing
   if (!score || !score.staves) {
@@ -219,6 +250,7 @@ export const useScoreLogic = (initialScore?: Partial<Score>) => {
     currentQuantsPerMeasure,
     dispatch,
     inputMode,
+    selectionEngine,
   });
 
   // Modifiers: duration, dots, accidentals, ties

--- a/src/hooks/useScoreLogic.ts
+++ b/src/hooks/useScoreLogic.ts
@@ -182,7 +182,13 @@ export const useScoreLogic = (initialScore?: Partial<Score>) => {
     const pending = selectionEngine.getPendingRestore();
     if (!pending) return;
     const current = selectionEngine.getState();
-    if (current.eventId !== null) return; // user moved on — leave their selection alone
+    if (current.eventId !== null) {
+      // The user moved on to a real selection — drop the stash entirely. Merely returning would
+      // leave it alive, so a LATER score change with an empty selection could re-resolve the (now
+      // re-materialized) event and spuriously re-select it (Codex P2 on #266).
+      selectionEngine.clearPendingRestore();
+      return;
+    }
     if (!resolveTarget(score, pending).ok) return; // not yet re-materialized (or never will be)
 
     const coord = {

--- a/src/services/TimelineService.ts
+++ b/src/services/TimelineService.ts
@@ -1,5 +1,6 @@
 import { TIME_SIGNATURES } from '@/constants';
 import { getNoteDuration } from '@/utils/core';
+import { findTieTarget } from '@/utils/ties';
 import { getFrequency } from './MusicService';
 import { getActiveStaff, Score, Staff, Measure, ScoreEvent, Note } from '@/types';
 
@@ -113,31 +114,47 @@ export const createTimeline = (score: Score, bpm: number): TimelineEvent[] => {
       return a.time - b.time;
     });
 
-    // Merge Ties (Linear Pass)
+    // Merge Ties (Linear Pass) — route connectivity through the tie SSOT (`findTieTarget`) instead
+    // of a float time-adjacency heuristic, so playback can never disagree with render/export/reflow
+    // about what a tie connects to (#261). A tie merges only when the SSOT resolves the chain's TAIL
+    // note to the literal coordinates of the next same-pitch event — a rest / reserved slot / wrong
+    // pitch between them breaks the chain exactly as it does everywhere else.
     if (rawEvents.length > 0) {
       let current = rawEvents[0];
+      // The last note absorbed into `current` — tie lookahead resolves from the chain's tail, not its
+      // head, so multi-note chains (C tied→C tied→C) extend across every link.
+      let tail = current;
 
       for (let i = 1; i < rawEvents.length; i++) {
         const next = rawEvents[i];
 
-        // Check connectivity
-        // Must be same pitch (guaranteed by sort usually, but check)
-        // Must be 'tied' flag on current
-        // Must be adjacent in time (within small epsilon float tolerance)
+        const target = tail.tied
+          ? findTieTarget(staff.measures, {
+              measureIndex: tail.measureIndex,
+              eventIndex: tail.eventIndex,
+              pitch: current.pitch,
+            })
+          : null;
         const isConnected =
-          current.tied &&
+          !!target &&
           next.pitch === current.pitch &&
-          Math.abs(next.time - (current.time + current.duration)) < 0.001;
+          target.measureIndex === next.measureIndex &&
+          target.eventIndex === next.eventIndex;
 
         if (isConnected) {
-          // Merge: Extend duration
-          current.duration += next.duration;
-          // Inherit tie status from next (if this chain continues)
-          current.tied = next.tied;
+          // Merge: extend the sounding span to the tied-to note's true grid END, then advance the
+          // tail so the chain can continue. Computing from `next.time + next.duration` (rather than
+          // `+= next.duration`) keeps the merged note aligned to the global grid even when the tie
+          // crosses a barline out of an under-full measure — there the events aren't time-contiguous,
+          // so a naive sum would both swallow the gap and lose the tied-to note's real onset. For a
+          // well-formed contiguous tie the two are identical.
+          current.duration = next.time + next.duration - current.time;
+          tail = next;
         } else {
           // Push finished event
           addEventToTimeline(current);
           current = next;
+          tail = next;
         }
       }
       // Push final event

--- a/src/utils/navigation/horizontal.ts
+++ b/src/utils/navigation/horizontal.ts
@@ -24,7 +24,7 @@ import {
   createGhostCursorResult,
 } from './previewNote';
 import { notesToAudioNotes } from './transposition';
-import { getStops, NavStop } from './stops';
+import { getStops, NavStop, buildTupletFillPreview } from './stops';
 import { getTupletRun } from '../tupletEdit';
 
 // --- Constants ---
@@ -110,19 +110,7 @@ const buildTupletFillGhost = (
   isRest: boolean
 ): HorizontalNavigationResult => ({
   selection: { staffIndex, measureIndex: null, eventId: null, noteId: null },
-  previewNote: {
-    measureIndex,
-    staffIndex,
-    quant: stop.quant,
-    visualQuant: stop.quant,
-    pitch,
-    duration: stop.baseDuration,
-    dotted: false,
-    mode: 'CHORD',
-    index: stop.reservedIndex,
-    eventId: stop.reservedId,
-    isRest,
-  },
+  previewNote: buildTupletFillPreview(measureIndex, staffIndex, stop, pitch, isRest),
   audio: null,
   shouldCreateMeasure: false,
 });

--- a/src/utils/navigation/stops.ts
+++ b/src/utils/navigation/stops.ts
@@ -15,7 +15,7 @@
  *
  * @see src/utils/navigation/horizontal.ts (consumes these for step-through + ghost cursors)
  */
-import { ScoreEvent, Measure } from '@/types';
+import { ScoreEvent, Measure, PreviewNote } from '@/types';
 import { getNoteDuration, getFirstNoteId, calculateTotalQuants } from '../core';
 import { getTupletRun } from '../tupletEdit';
 import { quantsEqual } from '../tuplet';
@@ -99,3 +99,51 @@ export const getStops = (measure: Measure, capacity: number): NavStop[] => {
 
   return stops;
 };
+
+/**
+ * The tuplet-fill stop whose free space contains `quant`, or null. A fill stop's free space spans
+ * from the stop itself to the next stop (the group's end), so an aligned quant landing anywhere in
+ * an incomplete tuplet's reserved region resolves to its single fill ghost. Used by cross-staff
+ * vertical navigation so it surfaces the same fill ghost the horizontal stops model does (#264),
+ * rather than landing on a blank reserved slot or jumping to events[0].
+ */
+export const findTupletFillAtQuant = (
+  measure: Measure,
+  capacity: number,
+  quant: number
+): Extract<NavStop, { kind: 'tupletFill' }> | null => {
+  const stops = getStops(measure, capacity);
+  for (let i = 0; i < stops.length; i++) {
+    const s = stops[i];
+    if (s.kind !== 'tupletFill') continue;
+    const upper = stops[i + 1]?.quant ?? capacity;
+    if (quant >= s.quant && quant < upper) return s;
+  }
+  return null;
+};
+
+/**
+ * Build a tuplet-fill ghost previewNote — a CHORD-mode preview anchored to the group's reserved slot
+ * (`eventId`), so committing it routes through the container-aware fill (useNoteEntry case A). Shared
+ * SSOT for the fill ghost so horizontal step-through and cross-staff vertical navigation stay in
+ * lockstep (#6 / #264).
+ */
+export const buildTupletFillPreview = (
+  measureIndex: number,
+  staffIndex: number,
+  stop: Extract<NavStop, { kind: 'tupletFill' }>,
+  pitch: string,
+  isRest: boolean
+): PreviewNote => ({
+  measureIndex,
+  staffIndex,
+  quant: stop.quant,
+  visualQuant: stop.quant,
+  pitch,
+  duration: stop.baseDuration,
+  dotted: false,
+  mode: 'CHORD',
+  index: stop.reservedIndex,
+  eventId: stop.reservedId,
+  isRest,
+});

--- a/src/utils/navigation/vertical.ts
+++ b/src/utils/navigation/vertical.ts
@@ -10,6 +10,7 @@
 import { calculateTotalQuants, getNoteDuration } from '../core';
 import { quantsEqual } from '../tuplet';
 import { getMidi } from '@/services/MusicService';
+import { getMeasureCapacity } from '@/constants';
 import { CONFIG } from '@/config';
 import {
   Note,
@@ -22,6 +23,7 @@ import {
 import { getAppendPreviewNote, getDefaultPitchForClef } from './previewNote';
 import { findEventAtQuantPosition, selectNoteInEventByDirection } from './crossStaff';
 import { getAdjustedDuration } from './horizontal';
+import { findTupletFillAtQuant, buildTupletFillPreview } from './stops';
 
 /**
  * Calculates cross-staff selection based on quant alignment.
@@ -108,25 +110,33 @@ export const calculateCrossStaffSelection = (
     };
   } else {
     // No event found at this time (Gap or Empty Measure)
-    // Fallback to "Append Position" using consistent logic
-
     // Determine Pitch: Default to a "middle" note for the staff clef.
     const clef = targetStaff.clef || 'treble';
     const defaultPitch = getDefaultPitchForClef(clef);
 
-    const previewNote = getAppendPreviewNote(
+    // If the aligned quant falls in an incomplete tuplet's free (reserved) space, surface a
+    // tuplet-fill ghost (parity with horizontal #6) so the cursor sits on the fillable slot and
+    // Enter fills it cross-staff — rather than dropping to a plain APPEND ghost (#264).
+    const fill = findTupletFillAtQuant(
       targetMeasure,
-      measureIndex,
-      targetStaffIndex,
-      activeDuration,
-      isDotted,
-      defaultPitch
+      getMeasureCapacity(score.timeSignature),
+      currentQuantStart
     );
+    const previewNote = fill
+      ? buildTupletFillPreview(measureIndex, targetStaffIndex, fill, defaultPitch, false)
+      : getAppendPreviewNote(
+          targetMeasure,
+          measureIndex,
+          targetStaffIndex,
+          activeDuration,
+          isDotted,
+          defaultPitch
+        );
 
     return {
       selection: {
         staffIndex: targetStaffIndex,
-        measureIndex,
+        measureIndex: fill ? null : measureIndex,
         eventId: null,
         noteId: null,
         selectedNotes: [],
@@ -259,7 +269,38 @@ export const calculateVerticalNavigation = (
             },
             previewNote: null,
           };
-        } else if (targetMeasure.events.length > 0) {
+        }
+
+        // The aligned quant lands in an incomplete tuplet's free (reserved) space — surface a
+        // tuplet-fill ghost so the cursor sits on the fillable slot and Enter fills it cross-staff,
+        // rather than jumping to events[0] (the first real event) and editing that instead (#264).
+        const ghostFill = findTupletFillAtQuant(
+          targetMeasure,
+          currentQuantsPerMeasure,
+          currentQuantStart
+        );
+        if (ghostFill) {
+          const fillPitch = getDefaultPitchForClef(targetStaff.clef || 'treble');
+          return {
+            selection: {
+              staffIndex: targetStaffIndex,
+              measureIndex: null,
+              eventId: null,
+              noteId: null,
+              selectedNotes: [],
+              anchor: null,
+            },
+            previewNote: buildTupletFillPreview(
+              ghostMeasureIndex,
+              targetStaffIndex,
+              ghostFill,
+              fillPitch,
+              previewNote.isRest ?? false
+            ),
+          };
+        }
+
+        if (targetMeasure.events.length > 0) {
           // No overlapping event, but measure has events - select first event
           const firstEvent = targetMeasure.events[0];
           return {
@@ -313,6 +354,29 @@ export const calculateVerticalNavigation = (
     // Cycle ghost cursor to opposite staff if measure exists and we're not already there
     if (cycleMeasure && cycleStaffIndex !== ghostStaffIndex) {
       const defaultPitch = getDefaultPitchForClef(cycleStaff.clef || 'treble');
+
+      // If the ghost's quant lands in the cycle target's tuplet free space, offer a fill ghost there
+      // (parity with the cross-staff fill ghost #264) rather than a plain APPEND ghost.
+      const cycleFill = findTupletFillAtQuant(cycleMeasure, currentQuantsPerMeasure, currentQuantStart);
+      if (cycleFill) {
+        return {
+          selection: {
+            staffIndex: cycleStaffIndex,
+            measureIndex: null,
+            eventId: null,
+            noteId: null,
+            selectedNotes: [],
+            anchor: null,
+          },
+          previewNote: buildTupletFillPreview(
+            ghostMeasureIndex,
+            cycleStaffIndex,
+            cycleFill,
+            defaultPitch,
+            previewNote.isRest ?? false
+          ),
+        };
+      }
 
       return {
         selection: {
@@ -446,6 +510,25 @@ export const calculateVerticalNavigation = (
           previewNote: null,
         };
       } else {
+        // If the aligned quant falls in an incomplete tuplet's free (reserved) space, surface a
+        // tuplet-fill ghost (parity with horizontal #6) so Enter fills the slot cross-staff, instead
+        // of a plain APPEND ghost over the bar's trailing space (#264).
+        const fill = findTupletFillAtQuant(targetMeasure, currentQuantsPerMeasure, currentQuantStart);
+        if (fill) {
+          const fillPitch = getDefaultPitchForClef(targetStaff.clef || 'treble');
+          return {
+            selection: {
+              staffIndex: targetStaffIndex,
+              measureIndex: null,
+              eventId: null,
+              noteId: null,
+              selectedNotes: [],
+              anchor: null,
+            },
+            previewNote: buildTupletFillPreview(measureIndex, targetStaffIndex, fill, fillPitch, false),
+          };
+        }
+
         // No event at this quant - show ghost cursor with adjusted duration
         const totalQuants = calculateTotalQuants(targetMeasure.events);
         // Snap to 0 when the bar is full within tuplet FP drift (parity with getStops' quantsEqual):
@@ -522,10 +605,35 @@ export const calculateVerticalNavigation = (
   const cycleMeasure = cycleStaff?.measures[measureIndex];
 
   if (cycleMeasure) {
-    // Find event at current quant in cycle target
+    // If the aligned quant lands in an incomplete tuplet's free (reserved) space, surface a fill
+    // ghost — `findEventAtQuantPosition` below is NOT reserved-aware (unlike the cross-staff overlap
+    // walks), so without this the cycle path would LAND on a blank reserved slot, the exact thing
+    // #264 set out to prevent. Checked before the event lookup so it always wins for reserved space.
+    const cycleFill = findTupletFillAtQuant(cycleMeasure, currentQuantsPerMeasure, currentQuantStart);
+    if (cycleFill) {
+      return {
+        selection: {
+          staffIndex: cycleStaffIndex,
+          measureIndex: null,
+          eventId: null,
+          noteId: null,
+          selectedNotes: [],
+          anchor: null,
+        },
+        previewNote: buildTupletFillPreview(
+          measureIndex,
+          cycleStaffIndex,
+          cycleFill,
+          getDefaultPitchForClef(cycleStaff.clef || 'treble'),
+          false
+        ),
+      };
+    }
+
+    // Find event at current quant in cycle target (never land on a reserved slot — see above).
     const cycleEvent = findEventAtQuantPosition(cycleMeasure, currentQuantStart);
 
-    if (cycleEvent) {
+    if (cycleEvent && !cycleEvent.reserved) {
       return {
         selection: {
           staffIndex: cycleStaffIndex,


### PR DESCRIPTION
Wraps up the loose ends from the M2 interactive-correctness work: the playback-lane verification gap (#261) plus three deferred follow-up bugs (#263, #264, #257). Built from a fan-out investigation and hardened by an adversarial multi-agent review (7 findings, all addressed).

## For musicians
- **Enter past a full last bar no longer drops the note** — it creates the next bar and places it, matching what a mouse click already did (#263).
- **Cross-staff cursor into a triplet's empty space lands on a fillable ghost** (ready for the next note) instead of jumping to the first note of the bar or onto a blank slot — now including when the cursor wraps from the last staff back to the first (#264).
- **Undo of a delete that emptied a bar restores the cursor** to the recovered note instead of leaving nothing selected (#257).
- **Playback agrees with the notation for ties** across tuplets and rests — a tie sounds only when it actually connects to the next note, so a tie interrupted by a rest no longer over-sustains (#261).

## For developers

**#261 — playback tie-merge routes through the SSOT.** `TimelineService` used a private float time-adjacency heuristic; it now routes tie connectivity through `findTieTarget` (`src/utils/ties.ts`), the same SSOT render/export/reflow use, so playback can't drift. Tracks the chain tail (multi-note chains still merge) and computes the merged span from the tied-to note's grid end (correct across an under-full bar; identical for well-formed ties). Probe tests cover tie+rest, tie-within-tuplet, meter-aware bar timing, and the cross-barline case. Chord-playback coordinate staleness stays scoped to #255.

**#263 — phantom-bar guard in `addNoteToMeasure`.** A keyboard Enter ghost past a full last bar targets `measureIndex + 1` (a bar that doesn't exist yet); the old code dispatched `AddEventCommand` against the missing measure → silent no-op. New guard (`measureIndex >= length && shouldAutoAdvance`) creates the bar then places into it, gated so the existing capacity-fail auto-advance recursion (which relies on the stale-`scoreRef`/engine split — the reason the prior fix was reverted) is untouched, and runs before the tuplet/slot branches so a stale selection can't be overwritten.

**#264 — cross-staff tuplet fill ghost.** Extracts `buildTupletFillPreview` + `findTupletFillAtQuant` into the stops SSOT; horizontal `buildTupletFillGhost` and **all** cross-staff vertical walks (overlap, ghost-cursor, event-cycle, ghost-cycle) now surface the same fill ghost. The staff-cycle path used `findEventAtQuantPosition`, which isn't reserved-aware and could land on a blank slot — fixed.

**#257 — restore selection on undo of an emptying delete.** `SelectionEngine` holds a single-slot `pendingRestore`; `useNoteDelete` stashes the pre-delete coord when a delete empties the selection (single selections only — true multi-deletes left unstashed to avoid partial restore). A `useScoreLogic` effect re-selects it when a later undo re-materializes the exact event — only while the selection is still empty, building a coherent single-selection. `loadScore`/`reset` clear the stash.

## Testing
- All **163 suites / 2953 tests** pass; lint + typecheck clean.
- New tests: TimelineService probes (#261), `appendPastFullBar` (#263), cross-staff + staff-cycle fill-ghost (#264), SelectionEngine stash + `useNoteDelete` stash-gating + end-to-end keyboard delete→undo→restore (#257).

## Notes
- Targets `dev`; issues are referenced (not closed) here and will auto-close on the next `dev → main` release PR.
- Out of scope / tracked elsewhere: chord-playback re-anchoring after reflow (#255); batching multi-note deletes into one undo step (a possible future improvement surfaced during review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)