### PR TITLE
Pre-release QA hardening: regressions + high-severity + localized fixes

### DIFF
--- a/src/__tests__/ChromaticTransposeCommand.test.ts
+++ b/src/__tests__/ChromaticTransposeCommand.test.ts
@@ -193,4 +193,35 @@ describe('ChromaticTransposeCommand', () => {
       }
     });
   });
+
+  describe('out-of-range staffIndex hardening (#242 Lane G parity / #QA)', () => {
+    // Collapse the default grand staff to a single staff so a selection still carrying staffIndex:1
+    // is stale/out-of-range — the realistic state after a grand→single downgrade.
+    const single = (pitch = 'C4'): Score => {
+      const score = createScoreWithNote(pitch);
+      return { ...score, staves: [score.staves[0]] };
+    };
+
+    test('Case 1: a stale out-of-range staffIndex no-ops (no phantom staff, note unchanged)', () => {
+      const score = single('C4');
+      const selection = { measureIndex: 0, staffIndex: 1, eventId: 'e1', noteId: 'n1', selectedNotes: [] };
+      const result = new ChromaticTransposeCommand(selection, 2).execute(score);
+      expect(result.staves).toHaveLength(1); // did NOT create a phantom staves[1]
+      expect(result.staves[0].measures[0].events[0].notes[0].pitch).toBe('C4'); // real note untouched
+    });
+
+    test('Case 0: a multi-note entry on an out-of-range staff is skipped, not thrown', () => {
+      const score = single('C4');
+      const selection = {
+        measureIndex: 0,
+        staffIndex: 0,
+        eventId: 'e1',
+        noteId: 'n1',
+        selectedNotes: [{ staffIndex: 1, measureIndex: 0, eventId: 'e1', noteId: 'n1' }],
+      };
+      expect(() => new ChromaticTransposeCommand(selection, 2).execute(score)).not.toThrow();
+      const result = new ChromaticTransposeCommand(selection, 2).execute(score);
+      expect(result.staves).toHaveLength(1);
+    });
+  });
 });

--- a/src/__tests__/ScoreAPI.navigation.test.tsx
+++ b/src/__tests__/ScoreAPI.navigation.test.tsx
@@ -593,6 +593,28 @@ describe('Navigation - select() bounds (#QA)', () => {
     expect(api.result.ok).toBe(true);
     expect(api.getSelection().eventId).toBe('e2');
   });
+
+  // The empty-measure carve-out is ONLY for the default append cursor (eventIndex 0).
+  const emptyMeasureStaves = (): Staff[] => [
+    { id: 'treble-staff', clef: 'treble', keySignature: 'C', measures: [{ id: 'm-empty', events: [] }] },
+  ];
+
+  test('explicit nonzero eventIndex on an EMPTY measure still reports EVENT_NOT_FOUND (Codex P2)', () => {
+    render(<RiffScore id="select-empty-explicit" config={configWithStaves(emptyMeasureStaves())} />);
+    const api = getAPI('select-empty-explicit');
+
+    api.select(0, 0, 99);
+    expect(api.result.ok).toBe(false);
+    expect(api.result.code).toBe('EVENT_NOT_FOUND');
+  });
+
+  test('default eventIndex 0 on an EMPTY measure is still ok (append-position selection)', () => {
+    render(<RiffScore id="select-empty-default" config={configWithStaves(emptyMeasureStaves())} />);
+    const api = getAPI('select-empty-default');
+
+    api.select(0); // default staffIndex/eventIndex/noteIndex = 0
+    expect(api.result.ok).toBe(true);
+  });
 });
 
 describe('Navigation - jump() Edge Cases', () => {

--- a/src/__tests__/ScoreAPI.navigation.test.tsx
+++ b/src/__tests__/ScoreAPI.navigation.test.tsx
@@ -559,6 +559,42 @@ describe('Navigation - selectById', () => {
   });
 });
 
+describe('Navigation - select() bounds (#QA)', () => {
+  afterEach(() => {
+    if (window.riffScore) {
+      window.riffScore.instances.clear();
+      window.riffScore.active = null;
+    }
+  });
+
+  test('out-of-range eventIndex on a non-empty measure reports EVENT_NOT_FOUND (not a false ok)', () => {
+    render(<RiffScore id="select-oob-event" config={configWithStaves(createSingleStaffStaves())} />);
+    const api = getAPI('select-oob-event');
+
+    api.select(0, 0, 99); // measure 0 has 2 events
+    expect(api.result.ok).toBe(false);
+    expect(api.result.code).toBe('EVENT_NOT_FOUND');
+  });
+
+  test('out-of-range noteIndex reports NOTE_NOT_FOUND', () => {
+    render(<RiffScore id="select-oob-note" config={configWithStaves(createSingleStaffStaves())} />);
+    const api = getAPI('select-oob-note');
+
+    api.select(0, 0, 0, 5); // event 0 exists, note index 5 does not
+    expect(api.result.ok).toBe(false);
+    expect(api.result.code).toBe('NOTE_NOT_FOUND');
+  });
+
+  test('a valid event index still selects (ok)', () => {
+    render(<RiffScore id="select-valid" config={configWithStaves(createSingleStaffStaves())} />);
+    const api = getAPI('select-valid');
+
+    api.select(0, 0, 1);
+    expect(api.result.ok).toBe(true);
+    expect(api.getSelection().eventId).toBe('e2');
+  });
+});
+
 describe('Navigation - jump() Edge Cases', () => {
   afterEach(() => {
     if (window.riffScore) {

--- a/src/__tests__/grandStaffBassTransposition.test.ts
+++ b/src/__tests__/grandStaffBassTransposition.test.ts
@@ -162,4 +162,25 @@ describe('Grand Staff Bass Clef Transposition', () => {
     score = engine.getState();
     expect(getActiveStaff(score, 1).measures[0].events[0].notes[0].pitch).toBe('G3');
   });
+
+  it('does not throw / create a phantom staff for a stale out-of-range staffIndex (Case 0, #267 Codex P2)', () => {
+    // Single-staff score, but a multi-note selection still carries a staffIndex:1 entry (the state
+    // after a grand→single downgrade). The earlier selectedNotes pass must skip it, not throw.
+    const base = createDefaultScore();
+    const single = { ...base, staves: [base.staves[0]] };
+    const eventId = single.staves[0].measures[0].events[0]?.id ?? 'none';
+    const selection = {
+      staffIndex: 0,
+      measureIndex: 0,
+      eventId,
+      noteId: null,
+      selectedNotes: [{ staffIndex: 1, measureIndex: 0, eventId, noteId: null }],
+    };
+
+    let result = single;
+    expect(() => {
+      result = new TransposeSelectionCommand(selection, 1, 'C').execute(single);
+    }).not.toThrow();
+    expect(result.staves).toHaveLength(1); // no phantom staves[1]
+  });
 });

--- a/src/__tests__/hooks/note/useNoteDelete.test.tsx
+++ b/src/__tests__/hooks/note/useNoteDelete.test.tsx
@@ -112,10 +112,17 @@ describe('useNoteDelete', () => {
       expect(mockSelectionEngine.stashPendingRestore).not.toHaveBeenCalled();
     });
 
-    it('deletes events when noteId is missing in selectedNotes', () => {
+    it('deletes events (DeleteEventCommand) for selectedNotes entries missing a noteId', () => {
+      // Two entries (a TRUE multi-selection) so it stays in the multi-delete branch — a single entry
+      // now intentionally falls through to the re-anchor path (see "single selection deletion").
       const selection: Selection = {
         ...createDefaultSelection(),
-        selectedNotes: [{ staffIndex: 0, measureIndex: 0, eventId: 'e1', noteId: null }],
+        measureIndex: 0,
+        eventId: 'e1',
+        selectedNotes: [
+          { staffIndex: 0, measureIndex: 0, eventId: 'e1', noteId: null },
+          { staffIndex: 0, measureIndex: 0, eventId: 'e2', noteId: null },
+        ],
       };
 
       const { result } = renderHook(() =>
@@ -126,7 +133,7 @@ describe('useNoteDelete', () => {
         result.current.deleteSelected();
       });
 
-      expect(DeleteEventCommand).toHaveBeenCalledTimes(1);
+      expect(DeleteEventCommand).toHaveBeenCalledTimes(2);
       expect(DeleteNoteCommand).not.toHaveBeenCalled();
     });
   });
@@ -195,6 +202,46 @@ describe('useNoteDelete', () => {
       act(() => result.current.deleteSelected());
 
       expect(mockSelect).toHaveBeenCalledWith(0, 'e2', 'e2n0', 0);
+    });
+
+    it('re-anchors a single-note (click-shape) selection to a neighbor — selectedNotes length 1 (#QA)', () => {
+      // A click/arrow-nav populates selectedNotes with ONE entry == the primary. That must still
+      // re-anchor to the surviving neighbor (M2 intent), NOT route to the multi-branch and clear.
+      const selection: Selection = {
+        ...createDefaultSelection(),
+        measureIndex: 0,
+        eventId: 'e1',
+        noteId: 'e1n0',
+        staffIndex: 0,
+        selectedNotes: [{ staffIndex: 0, measureIndex: 0, eventId: 'e1', noteId: 'e1n0' }],
+      };
+      const scoreRef = refTo(scoreWith([ev('e1', ['C4']), ev('e2', ['D4'])]));
+
+      const { result } = renderHook(() =>
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef })
+      );
+      act(() => result.current.deleteSelected());
+
+      expect(mockSelect).toHaveBeenCalledWith(0, 'e2', 'e2n0', 0);
+    });
+
+    it('re-anchors to a chord sibling when click-deleting one note of a chord — selectedNotes length 1 (#QA)', () => {
+      const selection: Selection = {
+        ...createDefaultSelection(),
+        measureIndex: 0,
+        eventId: 'e1',
+        noteId: 'e1n0',
+        staffIndex: 0,
+        selectedNotes: [{ staffIndex: 0, measureIndex: 0, eventId: 'e1', noteId: 'e1n0' }],
+      };
+      const scoreRef = refTo(scoreWith([ev('e1', ['C4', 'E4', 'G4'])]));
+
+      const { result } = renderHook(() =>
+        useNoteDelete({ selection, select: mockSelect, dispatch: mockDispatch, selectionEngine: mockSelectionEngine, scoreRef })
+      );
+      act(() => result.current.deleteSelected());
+
+      expect(mockSelect).toHaveBeenCalledWith(0, 'e1', 'e1n1', 0);
     });
 
     it('selects the previous event when deleting the last event', () => {

--- a/src/__tests__/navigationHelpers.test.ts
+++ b/src/__tests__/navigationHelpers.test.ts
@@ -520,4 +520,32 @@ describe('calculateVerticalNavigation', () => {
       expect(result?.selection?.noteId).toBe('cn2');
     });
   });
+
+  // #QA — descending from the chord track must use the chord's MEASURE-LOCAL coords (not quant-as-
+  // global), and must be able to land on a rest (symmetric with the rest-admitting UP path).
+  describe('chord-track DOWN navigation', () => {
+    const twoBarStaff = {
+      id: 'staff-0',
+      clef: 'treble' as const,
+      keySignature: 'C',
+      measures: [
+        { id: 'm0', events: [{ id: 'e0', duration: 'quarter', dotted: false, notes: [{ id: 'e0n', pitch: 'C4' }] }] },
+        { id: 'm1', events: [{ id: 'e1', duration: 'quarter', dotted: false, isRest: true, notes: [] }] },
+      ],
+    };
+    const scoreWithChord = {
+      ...createScore([twoBarStaff]),
+      chordTrack: [{ id: 'ch1', measure: 1, quant: 0, symbol: 'G' }],
+    };
+
+    test('descends to the chord’s own (non-zero) measure and lands on a rest', () => {
+      const selection = { staffIndex: 0, measureIndex: null, eventId: null, noteId: null };
+      // args: ..., previewNote=null, qpm=64, chordTrackFocused=true, selectedChordId='ch1'
+      const result = calculateVerticalNavigation(scoreWithChord, selection, 'down', 'quarter', false, null, 64, true, 'ch1');
+
+      expect(result?.leavingChordTrack).toBe(true);
+      expect(result?.selection?.measureIndex).toBe(1); // chord.measure — NOT floor(quant/qpm)=0
+      expect(result?.selection?.eventId).toBe('e1'); // the rest in measure 1 (rest is a valid landing)
+    });
+  });
 });

--- a/src/__tests__/utils/navigation/stops.test.ts
+++ b/src/__tests__/utils/navigation/stops.test.ts
@@ -3,9 +3,10 @@
  * an incomplete tuplet contributes ONE `tupletFill` ghost stop (reserved slots are never their own
  * stop); a bar with room contributes a trailing `append` stop.
  */
-import { getStops } from '@/utils/navigation/stops';
+import { getStops, findTupletFillAtQuant } from '@/utils/navigation/stops';
 import { Measure, ScoreEvent } from '@/types';
 import { getMeasureCapacity } from '@/constants';
+import { getNoteDuration } from '@/utils/core';
 
 const cap = getMeasureCapacity('4/4');
 const note = (id: string, duration: string, pitch = 'C4'): ScoreEvent => ({
@@ -65,5 +66,20 @@ describe('getStops', () => {
 
   it('an empty bar is just an append stop', () => {
     expect(kinds(getStops(measure([]), cap))).toEqual(['append']);
+  });
+
+  it('emits stops in quant order even when a reserved slot is non-trailing (#264 QA)', () => {
+    // Loaded/malformed ordering [real, reserved, real] — normal editing packs reserved to the end,
+    // but loadScore accepts any order. The fill ghost must sort between the two real members so its
+    // free-space range can't span (and shadow) the second real member.
+    const m = measure([trip('a', 'C4', 0), trip('r', null, 1, true), trip('b', 'E4', 2)]);
+    const stops = getStops(m, cap);
+    expect(kinds(stops)).toEqual(['note', 'tupletFill', 'note', 'append']);
+    const quants = stops.map((s) => s.quant);
+    expect(quants).toEqual([...quants].sort((x, y) => x - y)); // strictly ascending
+
+    const memberQ = getNoteDuration('eighth', false, { ratio: [3, 2] });
+    expect(findTupletFillAtQuant(m, cap, memberQ)).not.toBeNull(); // inside the reserved region
+    expect(findTupletFillAtQuant(m, cap, memberQ * 2)).toBeNull(); // the 2nd real member — NOT shadowed
   });
 });

--- a/src/commands/ChromaticTransposeCommand.ts
+++ b/src/commands/ChromaticTransposeCommand.ts
@@ -9,7 +9,7 @@
  */
 
 import { Command } from './types';
-import { Score, getActiveStaff, Selection, Staff, ScoreEvent, Note as NoteType } from '@/types';
+import { Score, getValidStaff, Selection, Staff, ScoreEvent, Note as NoteType } from '@/types';
 import { Note, Interval } from 'tonal';
 import { PIANO_RANGE } from '@/constants';
 import { getMidi } from '@/services/MusicService';
@@ -79,8 +79,10 @@ export class ChromaticTransposeCommand implements Command {
     }
 
     const staffIndex = this.selection.staffIndex ?? 0;
-    const activeStaff = getActiveStaff(score, staffIndex);
-    const measure = activeStaff.measures[this.selection.measureIndex];
+    // getValidStaff (not getActiveStaff) so a stale out-of-range staffIndex resolves to undefined and
+    // no-ops, rather than silently retargeting staff 0 (#242 Lane G — parity with the diatonic sibling).
+    const activeStaff = getValidStaff(score, staffIndex);
+    const measure = activeStaff?.measures[this.selection.measureIndex];
     if (!measure) return targets;
 
     // Case 1: specific note
@@ -189,6 +191,11 @@ export class ChromaticTransposeCommand implements Command {
         // different key signatures (grand staff) spells each note in its own key.
         const keySig = score.staves[sIdx]?.keySignature || this.keySignature || 'C';
 
+        // Skip a selectedNotes entry whose staff no longer exists (e.g. a stale grand-staff selection
+        // after a single-staff downgrade) — `[...newStaves[sIdx].measures]` would otherwise throw on
+        // undefined, dropping the WHOLE transpose into the dispatch catch (#242 Lane G parity).
+        if (!getValidStaff(score, sIdx)) return;
+
         if (!staffMap.has(sIdx)) {
           staffMap.set(sIdx, {
             ...newStaves[sIdx],
@@ -248,7 +255,8 @@ export class ChromaticTransposeCommand implements Command {
     }
 
     // Case 1: Transpose specific note
-    const activeStaff = getActiveStaff(score, staffIndex);
+    const activeStaff = getValidStaff(score, staffIndex);
+    if (!activeStaff) return score; // out-of-range staff -> no-op (don't retarget staff 0)
     const keySig = activeStaff.keySignature || this.keySignature || 'C';
     const newMeasures = [...activeStaff.measures];
 

--- a/src/commands/ToggleRestCommand.ts
+++ b/src/commands/ToggleRestCommand.ts
@@ -61,6 +61,11 @@ export class ToggleRestCommand implements Command {
   constructor(private selection: Selection) {}
 
   execute(score: Score): Score {
+    // Reset the snapshot so re-execution (redo reuses this same command instance) re-captures the
+    // pre-image fresh instead of appending — otherwise the array doubles on every redo (#QA). Mirrors
+    // ApplyTupletCommand.execute().
+    this.previousStates = [];
+
     // Collect unique events from selection
     const eventMap = new Map<
       string,

--- a/src/commands/TransposeSelectionCommand.ts
+++ b/src/commands/TransposeSelectionCommand.ts
@@ -168,6 +168,10 @@ export class TransposeSelectionCommand implements Command {
 
       this.selection.selectedNotes.forEach((sn) => {
         const sIndex = sn.staffIndex;
+        // Skip a stale out-of-range staffIndex BEFORE the deref below — this earlier pass would
+        // otherwise throw on `[...undefined.measures]` before the guard in the notesByMeasure loop is
+        // reached (Codex P2 on #267; the chromatic sibling has no such early pass).
+        if (!getValidStaff(score, sIndex)) return;
         let currentStaff = staffMap.get(sIndex);
         if (!currentStaff) {
           // First time touching this staff, copy it from newStaves (which starts as shallow copy of score.staves)

--- a/src/commands/TransposeSelectionCommand.ts
+++ b/src/commands/TransposeSelectionCommand.ts
@@ -225,6 +225,11 @@ export class TransposeSelectionCommand implements Command {
         const sIdx = parseInt(sIdxStr, 10);
         const mIdx = parseInt(mIdxStr, 10);
 
+        // Skip a selectedNotes entry whose staff no longer exists (stale grand-staff selection after a
+        // single-staff downgrade) — the spread below would otherwise throw on undefined and drop the
+        // whole transpose (#242 Lane G parity; the Case 1/2 paths above already use getValidStaff).
+        if (!getValidStaff(score, sIdx)) return;
+
         // Ensure we have a working copy of the staff
         if (!staffMap.has(sIdx)) {
           staffMap.set(sIdx, {

--- a/src/hooks/api/chords.ts
+++ b/src/hooks/api/chords.ts
@@ -206,6 +206,7 @@ export const createChordMethods = (
         syncSelection({
           ...sel,
           chordId: null,
+          chordTrackFocused: false, // drop focus with the id so vertical nav isn't left swallowed (#QA)
         });
       }
 
@@ -381,6 +382,7 @@ export const createChordMethods = (
       syncSelection({
         ...sel,
         chordId: null,
+        chordTrackFocused: false, // leaving the chord drops track focus (coherent no-chord state) (#QA)
       });
 
       setResult({
@@ -798,6 +800,7 @@ export const createChordMethods = (
       syncSelection({
         ...sel,
         chordId: newChordId,
+        chordTrackFocused: newChordId !== null, // an emptied track drops focus (#QA)
       });
 
       setResult({

--- a/src/hooks/api/navigation.ts
+++ b/src/hooks/api/navigation.ts
@@ -283,11 +283,14 @@ export const createNavigationMethods = (
       }
 
       // Bounds-check the event/note so an out-of-range index reports a failure instead of a false ok
-      // + silent append-to-end (mirrors selectAtQuant/selectById). An EMPTY measure with the default
-      // eventIndex 0 is allowed — that's a measure/append-position selection, not an error.
+      // + silent append-to-end (mirrors selectAtQuant/selectById). The ONLY carve-out is the default
+      // append cursor — eventIndex 0 on an EMPTY measure (a measure/append-position selection). An
+      // explicit nonzero index that resolves to nothing is still EVENT_NOT_FOUND, even in an empty bar
+      // (Codex P2 on #267).
       const targetMeasure = staff.measures[measureIndex];
       const targetEvent = targetMeasure.events[eventIndex];
-      if (targetMeasure.events.length > 0 && !targetEvent) {
+      const isEmptyMeasureAppendCursor = targetMeasure.events.length === 0 && eventIndex === 0;
+      if (!targetEvent && !isEmptyMeasureAppendCursor) {
         setResult({
           ok: false,
           status: 'error',

--- a/src/hooks/api/navigation.ts
+++ b/src/hooks/api/navigation.ts
@@ -282,6 +282,32 @@ export const createNavigationMethods = (
         return this;
       }
 
+      // Bounds-check the event/note so an out-of-range index reports a failure instead of a false ok
+      // + silent append-to-end (mirrors selectAtQuant/selectById). An EMPTY measure with the default
+      // eventIndex 0 is allowed — that's a measure/append-position selection, not an error.
+      const targetMeasure = staff.measures[measureIndex];
+      const targetEvent = targetMeasure.events[eventIndex];
+      if (targetMeasure.events.length > 0 && !targetEvent) {
+        setResult({
+          ok: false,
+          status: 'error',
+          method: 'select',
+          message: `Event index ${eventIndex} not found in measure ${measureIndex}`,
+          code: 'EVENT_NOT_FOUND',
+        });
+        return this;
+      }
+      if (targetEvent && noteIndex !== 0 && !targetEvent.notes[noteIndex]) {
+        setResult({
+          ok: false,
+          status: 'error',
+          method: 'select',
+          message: `Note index ${noteIndex} not found in measure ${measureIndex}`,
+          code: 'NOTE_NOT_FOUND',
+        });
+        return this;
+      }
+
       // Use SelectEventCommand for proper selection
       selectionEngine.dispatch(
         new SelectEventCommand({

--- a/src/hooks/note/useNoteDelete.ts
+++ b/src/hooks/note/useNoteDelete.ts
@@ -70,8 +70,7 @@ export function useNoteDelete({
     // Stash the pre-delete primary coord before clearing the selection to null (#257), so the next
     // undo that re-materializes that exact event/note (ids are stable across undo) re-selects it —
     // the Lane G repair effect only prunes, never re-anchors. EventIds are unique, so the stash can
-    // only resolve by undoing this delete; it can't fire on an unrelated edit. Used by both the
-    // multi-selection clear and the single no-neighbor clear below.
+    // only resolve by undoing this delete; it can't fire on an unrelated edit.
     const stashClearedSelection = () => {
       if (selection.measureIndex !== null && selection.eventId) {
         selectionEngine.stashPendingRestore({
@@ -83,8 +82,13 @@ export function useNoteDelete({
       }
     };
 
-    // 1. Delete Multi-Selection
-    if (selection.selectedNotes && selection.selectedNotes.length > 0) {
+    // 1. Delete a TRUE multi-selection (more than one note). A single-note selection — which a click
+    // or arrow-key nav produces (SetSelectionCommand/NavigateCommand populate selectedNotes with one
+    // entry == the primary) — deliberately falls through to the single-selection path below so it
+    // re-anchors to a surviving neighbor / chord sibling (the M2 UX intent) instead of clearing to
+    // null. A genuine multi-delete clears (which survivor to anchor is ambiguous) and is left
+    // unstashed: it dispatches N separate history entries, so one undo would only restore the last.
+    if (selection.selectedNotes && selection.selectedNotes.length > 1) {
       const notesToDelete = [...selection.selectedNotes];
       notesToDelete.forEach((note) => {
         if (note.noteId) {
@@ -96,12 +100,6 @@ export function useNoteDelete({
           dispatch(new DeleteEventCommand(note.measureIndex, note.eventId, note.staffIndex));
         }
       });
-      // Clear selection after delete. Only stash for a single-note selection (a click populates
-      // selectedNotes with one entry == the primary): a true multi-note delete dispatches N separate
-      // history entries, so one undo restores only the last and a primary-coord stash would re-select
-      // partially or mis-fire on a later undo (#257 review). Re-anchoring a multi-delete undo is out
-      // of #257 scope — leave it unstashed.
-      if (notesToDelete.length === 1) stashClearedSelection();
       select(null, null, null, selection.staffIndex);
       return;
     }

--- a/src/hooks/useScoreLogic.ts
+++ b/src/hooks/useScoreLogic.ts
@@ -182,10 +182,12 @@ export const useScoreLogic = (initialScore?: Partial<Score>) => {
     const pending = selectionEngine.getPendingRestore();
     if (!pending) return;
     const current = selectionEngine.getState();
-    if (current.eventId !== null) {
-      // The user moved on to a real selection — drop the stash entirely. Merely returning would
-      // leave it alive, so a LATER score change with an empty selection could re-resolve the (now
-      // re-materialized) event and spuriously re-select it (Codex P2 on #266).
+    // "Moved on" = the user established ANY real selection since the delete — a note (eventId) OR the
+    // chord track (chordTrackFocused/chordId, both of which leave eventId null). Drop the stash so it
+    // can't later clobber that deliberate selection. (Merely returning would leave it alive to
+    // re-resolve on a future empty-selection score change — Codex P2 on #266; the chord-track case is
+    // the QA follow-up.)
+    if (current.eventId !== null || current.chordTrackFocused || current.chordId) {
       selectionEngine.clearPendingRestore();
       return;
     }
@@ -197,11 +199,15 @@ export const useScoreLogic = (initialScore?: Partial<Score>) => {
       eventId: pending.eventId,
       noteId: pending.noteId,
     };
+    // Build a fully coherent single-note selection — clear chord fields explicitly rather than
+    // spreading them, so the restored note can't coexist with a stale chord focus.
     selectionEngine.setState({
       ...current,
       ...coord,
       selectedNotes: [coord],
       anchor: coord,
+      chordId: null,
+      chordTrackFocused: false,
     });
     selectionEngine.clearPendingRestore();
   }, [score, selectionEngine]);

--- a/src/utils/navigation/stops.ts
+++ b/src/utils/navigation/stops.ts
@@ -97,6 +97,12 @@ export const getStops = (measure: Measure, capacity: number): NavStop[] => {
     stops.push({ kind: 'append', quant: total });
   }
 
+  // Emit in quant order (the contract above). A group's single `tupletFill` ghost is pushed AFTER
+  // its real members, so a reserved slot that isn't trailing (only reachable via loaded/malformed
+  // data — normal editing packs reserved to the end) would otherwise leave the array quant-unordered,
+  // making `findTupletFillAtQuant`'s next-stop upper bound span a real member and shadow it (#264 QA).
+  stops.sort((a, b) => a.quant - b.quant);
+
   return stops;
 };
 

--- a/src/utils/navigation/vertical.ts
+++ b/src/utils/navigation/vertical.ts
@@ -189,22 +189,28 @@ export const calculateVerticalNavigation = (
   if (chordTrackFocused && direction === 'down' && selectedChordId) {
     const selectedChord = score.chordTrack?.find((c) => c.id === selectedChordId);
     if (selectedChord) {
-      const targetMeasureIndex = Math.floor(selectedChord.quant / currentQuantsPerMeasure);
-      const localQuant = selectedChord.quant % currentQuantsPerMeasure;
+      // ChordSymbol.{measure,quant} is MEASURE-LOCAL — use the fields directly. (The old
+      // Math.floor(quant/qpm) decomposition treated quant as a global offset and ignored
+      // chord.measure, landing in the wrong bar / stranding the user on the chord track.)
+      const targetMeasureIndex = selectedChord.measure;
+      const localQuant = selectedChord.quant;
       const topStaff = score.staves[0];
       const targetMeasure = topStaff?.measures[targetMeasureIndex];
 
       if (targetMeasure) {
-        // Find event at this quant
+        // Land on the event that STARTS at this quant — a note OR a notated rest (symmetric with the
+        // UP-to-chord path, which admits rests; a chord can sit over a rest, so descending must be
+        // able to return to it). Never land on a blank reserved tuplet slot. quantsEqual tolerates a
+        // chord anchored on a fractional tuplet-member quant.
         let currentQuant = 0;
         for (const event of targetMeasure.events) {
-          if (currentQuant === localQuant && !event.isRest && event.notes?.length > 0) {
+          if (quantsEqual(currentQuant, localQuant) && !event.reserved) {
             return {
               selection: {
                 staffIndex: 0,
                 measureIndex: targetMeasureIndex,
                 eventId: event.id,
-                noteId: event.notes[0].id,
+                noteId: event.notes?.[0]?.id ?? null,
                 selectedNotes: [],
                 anchor: null,
               },
@@ -220,8 +226,10 @@ export const calculateVerticalNavigation = (
     return null;
   }
 
-  // If on chord track and going UP, no action (already at top)
-  if (chordTrackFocused && direction === 'up') {
+  // If GENUINELY on the chord track and going UP, no action (already at top). Gate on selectedChordId
+  // too so a dangling chordTrackFocused:true with no chord (e.g. after the focused chord was removed)
+  // can't silently swallow Cmd+Up for note navigation (#QA defense-in-depth).
+  if (chordTrackFocused && selectedChordId && direction === 'up') {
     return null;
   }
 

--- a/src/utils/selectionRepair.ts
+++ b/src/utils/selectionRepair.ts
@@ -124,5 +124,9 @@ export const repairSelection = (selection: Selection, score: Score): Selection =
     anchor: anchorStale ? null : selection.anchor,
     verticalAnchors: verticalChanged ? prunedVertical : selection.verticalAnchors,
     chordId: chordStale ? null : selection.chordId,
+    // Drop chord-track focus alongside the chord id — leaving chordTrackFocused:true with chordId:null
+    // is the incoherent state createDefaultSelection never produces, and vertical.ts reads the flag
+    // alone (swallowing Cmd+Up) (#QA).
+    chordTrackFocused: chordStale ? false : selection.chordTrackFocused,
   };
 };


### PR DESCRIPTION
Remediation from the **deep-QA audit of `dev`** (24 confirmed findings). This PR fixes the **2 regressions** the M2 close-the-loop work introduced, the **high-severity** transpose data-corruption, and the **cheap localized** findings. Larger pre-existing items are filed, not fixed here (see "Filed, not fixed").

Built from the audit's per-finding adversarial verification; every behavior change carries a regression test. **163 suites / 2963 tests pass; typecheck + lint clean.**

## For musicians
- Deleting one note of a chord, or one of several notes in a bar (click or arrow keys), now moves the cursor to a neighbor instead of clearing the selection.
- Undo no longer hijacks the chord track: delete a note → click a chord → undo keeps the chord selected.
- Cmd+Down off the chord track lands in the chord's real bar and can land on a rest (no wrong-measure jump / stuck cursor).

## For developers (what's fixed)
| ID | Sev | Fix |
|---|---|---|
| **R1** | regression (#257) | restore-effect "moved on" guard now also checks `chordTrackFocused`/`chordId`; restore builds a coherent single-note selection (clears chord fields) |
| **R2** | regression (#264) | `getStops` sorts by quant → a non-trailing reserved slot (loaded/malformed data) can't make `findTupletFillAtQuant` shadow a real member |
| **H1** | high | `ChromaticTranspose`/`TransposeSelection` resolve via `getValidStaff` + skip out-of-range `staffIndex` (Case 0/1) — no phantom staff, no throw (mirrors the #242 Lane G hardening already on the diatonic Case 1/2 paths) |
| — | low | `ToggleRestCommand` resets `previousStates` per `execute` (no redo doubling) |
| — | med | chord-track DOWN nav uses measure-local quant + admits rests |
| — | med | single-note delete (`selectedNotes` length 1) routes to the re-anchor path (was clearing) |
| — | low | `chordTrackFocused` paired with `chordId` in repair/removeChord/deselect/deleteSelectedChord (+ vertical up-guard requires `selectedChordId`) |
| — | low | `navigation.select()` bounds-checks event/note index (`EVENT_NOT_FOUND`/`NOTE_NOT_FOUND`) instead of a false `ok` + silent append |

## Regression tests added
single-note + chord-sibling re-anchor; R2 quant-ordered stops (non-trailing reserved → no shadow); transpose stale-`staffIndex` no-op (Case 0 + 1); chord-track-down (measure-local + lands on a rest); `select()` out-of-range → `EVENT_/NOTE_NOT_FOUND`.

## Filed, not fixed (pre-existing, tracked separately)
- **#254** — playback/layout read `TIME_SIGNATURES[…] || 64` instead of `getMeasureCapacity`, desyncing meters outside the 4-entry table (9/8, 12/8, 5/4, 3/8, 7/8) across timeline, chord playback, layout, hit-test (its own milestone).
- **#255** — chord anchors aren't re-anchored across time-sig reflow; chord playback ignores pickup bars.
- Plus: tuplet-fill leaves the new note unselected; cross-barline tie exports a tie-over-a-rest (MusicXML/ABC); cross-system & justified-tie rendering in page view; MIDI chord overfill; cross-barline-entry two-undo granularity; reflow event-id re-mint; chord float-`===` matching; `addTone` reserved-slot parity. (Filed as issues.)

Targets `dev`; merges to `main` with the pending release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)