### PR TITLE
[codex] M3: export and engraving fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ the rendered page, and the MusicXML/ABC that users share with notation apps.
 ### For musicians
 - **MusicXML exports import more faithfully** — minor keys now carry `<mode>`, empty grand-staff
   staves export explicit whole-measure rests, tuplet chord members no longer duplicate bracket
-  notations, and extended/slash chord symbols retain more of their musical meaning.
-- **ABC exports handle pickups and tuplets better** — pickup bars emit their own temporary meter,
-  quintuplets keep their correct ratio, final barlines are pinned, and chord symbols on fractional
-  tuplet positions are no longer dropped.
+  notations, and extended/altered chord symbols (9ths, 11ths, 13ths, add/alter tones) export with
+  more of their harmonic detail. *(This affects the exported file only — how chords look and play
+  inside the editor is unchanged.)*
+- **ABC exports handle pickups and tuplets better** — pickup bars now emit their own temporary
+  meter, and chord symbols anchored on fractional tuplet positions are no longer dropped.
 - **Ties and beams line up with what you see** — cross-measure ties use the same key-aware/stretched
   layout as noteheads, and mixed dotted/16th rhythms now render primary, secondary, and partial beams
   instead of splitting the beat.
@@ -30,7 +31,9 @@ the rendered page, and the MusicXML/ABC that users share with notation apps.
   and beamlet spans from layout data instead of inferring full-width inner beams from duration.
 - The MusicXML structural helper now validates staff duration streams, `<backup>` durations, note
   child order, tuplet notation placement, and full-measure rests; representative real exporter
-  outputs run through this validator in Jest/CI.
+  outputs — including a tuplet-containing score — run through this validator in Jest/CI. The
+  official MusicXML 4.0 XSD-in-CI check (audit Phase 2) is **not** part of this release and remains
+  an open verification item.
 
 ## [1.0.0-alpha.16] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+M3 export & engraving fidelity. This closes the remaining practical gaps between the score model,
+the rendered page, and the MusicXML/ABC that users share with notation apps.
+
+### For musicians
+- **MusicXML exports import more faithfully** — minor keys now carry `<mode>`, empty grand-staff
+  staves export explicit whole-measure rests, tuplet chord members no longer duplicate bracket
+  notations, and extended/slash chord symbols retain more of their musical meaning.
+- **ABC exports handle pickups and tuplets better** — pickup bars emit their own temporary meter,
+  quintuplets keep their correct ratio, final barlines are pinned, and chord symbols on fractional
+  tuplet positions are no longer dropped.
+- **Ties and beams line up with what you see** — cross-measure ties use the same key-aware/stretched
+  layout as noteheads, and mixed dotted/16th rhythms now render primary, secondary, and partial beams
+  instead of splitting the beat.
+
+### For developers
+- MusicXML/ABC chord anchors now quantize through the shared chord quantizer, so fractional tuplet
+  positions are stable across exporters.
+- MusicXML harmony export adds broader kind mapping and `<degree>` output for add/alter tones, plus
+  stricter note-order/tuplet/rest behavior covered by exporter tests.
+- `BeamGroup` now carries explicit per-level beam segments; the renderer draws primary, secondary,
+  and beamlet spans from layout data instead of inferring full-width inner beams from duration.
+- The MusicXML structural helper now validates staff duration streams, `<backup>` durations, note
+  child order, tuplet notation placement, and full-measure rests; representative real exporter
+  outputs run through this validator in Jest/CI.
+
 ## [1.0.0-alpha.16] - 2026-06-13
 
 Closes the loop on the M2 interactive-correctness work — the four deferred follow-ups (#261, #263,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # RiffScore Roadmap
 
-> **Generated:** 2026-06-13 · **Living document** · reflects state through **v1.0.0-alpha.16**: M1 (truth-in-advertising) shipped in **alpha.13**; M2's **#239 (transpose spelling)** shipped in **alpha.14**; M2's **#242 (interactive correctness / structural invariants)** and the **#252 visual-regression harness** shipped in **alpha.15**; M2's deferred follow-ups **#261/#263/#264/#257** + pre-release QA hardening shipped in **alpha.16** (which also re-scoped **#245**).
+> **Generated:** 2026-06-23 · **Living document** · reflects state through **v1.0.0-alpha.16** plus **Unreleased M3**: M1 (truth-in-advertising) shipped in **alpha.13**; M2's **#239 (transpose spelling)** shipped in **alpha.14**; M2's **#242 (interactive correctness / structural invariants)** and the **#252 visual-regression harness** shipped in **alpha.15**; M2's deferred follow-ups **#261/#263/#264/#257** + pre-release QA hardening shipped in **alpha.16**; **M3 export/engraving fidelity** is complete on the integration branch and pending release.
 > Grounded in the 2026-06 correctness audit ([CORRECTNESS_AUDIT_2026-06.md](audit/CORRECTNESS_AUDIT_2026-06.md),
 > [AUDIT_QA_2026-06.md](audit/AUDIT_QA_2026-06.md)) and re-sequenced per the audit's
 > own second-pass QA. Every load-bearing claim below was independently fact-checked
@@ -44,6 +44,10 @@ release now on `dev` / [PR #248](https://github.com/joekotvas/RiffScore/pull/248
   `<divisions>` (LCM of tuplet denominators), grand-staff as one `<part>` with
   `<staves>` + `<backup>`, pickup `implicit="yes"`, score-level `<fifths>`; ABC
   measure-local accidental cancellation (#240, #238, #234).
+- **M3 export/engraving tail** *(Unreleased / pending release)* — MusicXML key mode,
+  whole-measure rests for empty grand-staff staves, slash/extended harmony mapping,
+  stricter note-order/tuplet/rest structural validation, ABC pickup meters/final barline/
+  tuplet chord anchors, key-aware tie layout, and mixed-value secondary/partial beams.
 - **Transpose lossless undo** — both transpose commands snapshot the pre-image and
   restore verbatim (contract C3).
 - **Migration versioning** — `SCHEMA_VERSION` bumped to **2** so scores saved at v1
@@ -120,25 +124,33 @@ silently; transpose preserves spelling; partial tuplets can't corrupt capacity/a
 
 ---
 
-### M3 — Export & engraving fidelity · *medium*
+### M3 — Export & engraving fidelity · ✅ *done (Unreleased / pending release)*
 
 With a trustworthy model, make what gets shared and printed match it exactly.
 
-- **MusicXML tail** — `<tie>`/`<dot>` DTD child-ordering (strict parsers like Finale
-  reject the current order); tuplet `<duration>` sums to `divisions·beats`; #246
-  (empty grand-staff staff emits a whole-measure rest; **MusicXML 4.0 XSD validation in
-  CI**); #216 slash-chord `<harmony>`.
-- **ABC tail** — quintuplet ratio, final barline `|]`, and the export test coverage the
-  audit found missing.
-- **Beaming sub-grouping #245 (the no-dependency half)** — dotted-rhythm grouping and
-  secondary/partial beams (16th-within-8th). *The tuplet-beaming half of #245 depends on
-  #237 and is deferred with it.*
-- **Tie layout key (#249)** — cross-measure tie endpoint X is computed with the default
-  key `'C'` (`Staff.tsx`), so tie ends can diverge slightly from noteheads in non-C keys.
-  One-line fix (thread the score key); parallels the #245 `useMeasureLayout` gap.
+- ✅ **MusicXML tail** — note child-ordering remains parser-safe; tuplet durations sum to
+  `divisions·beats`; #246 empty grand-staff staves emit `<rest measure="yes"/>`; minor
+  keys emit `<mode>`; tuplet bracket notations are primary-note only; slash and extended
+  chord symbols map into richer `<harmony>` / `<degree>` output.
+- ✅ **MusicXML structural validation** — representative real exporter output now runs
+  through a deterministic Jest gate that checks staff duration streams, `<backup>`
+  durations, note child order, tuplet notation placement, and full-measure rests. The
+  committed reduced XSD fixture remains documented; wiring the full official MusicXML
+  4.0 XSD bundle into CI is now a hardening follow-up, not a blocker for the M3 defects
+  above.
+- ✅ **ABC tail** — quintuplet ratios, final barline `|]`, pickup-meter annotation, and
+  fractional tuplet chord anchors are covered by exporter tests.
+- ✅ **Beaming sub-grouping #245 (the no-dependency half)** — dotted-rhythm grouping and
+  secondary/partial beam segments now render from layout data (for example 8th+16th+16th
+  and dotted-8th+16th). *The tuplet-beaming half of #245 depends on #237 and remains
+  deferred with it.*
+- ✅ **Tie layout key (#249)** — cross-measure tie endpoint X now uses the same
+  key-aware/stretched measure layout as rendered noteheads, including direct Measure
+  fallback paths.
 
-**Done when:** a representative export validates against the MusicXML 4.0 XSD in CI;
-round-trips are pinned; ABC/MusicXML are musically identical to the render.
+**Done when:** MusicXML/ABC exports and on-canvas engraving agree for the M3 defect
+classes, and representative exports are covered by structural CI tests. — ✅ **Met**
+for the scoped M3 tail; full official-XSD CI remains a follow-up hardening item.
 
 ---
 
@@ -182,15 +194,16 @@ dynamics (#20/#21), slurs (#19), lyrics (#30), repeats (#28), inline key/time ch
 ## Critical path
 
 ```
-M1 (truth) ✅  →  M2 (#239 ✅ → #242 ✅)  →  M3 (export/engraving)  →  (M4 decision)  →  M5
+M1 (truth) ✅  →  M2 (#239 ✅ → #242 ✅)  →  M3 (export/engraving) ✅  →  (M4 decision)  →  M5
 ```
 
 **M2 is shipped** (#239 in alpha.14, #242 in alpha.15) — it was the long pole. Its deferred
-follow-ups **#261, #263, #264, #257 shipped in alpha.16** (close-the-loop), which also re-scoped
-**#245** (tuplet rendering verified). **M3 (export/engraving) is next.** M4 (page view) and M5 (chord
-theory) are largely independent of each other and can run in parallel. Remaining M2-adjacent
-follow-ups: #255 (chord reflow re-anchoring / pickup playback), the capacity SSOT #254, and the
-partials #246/#237 — plus QA-pass items #268–#272.
+follow-ups **#261, #263, #264, #257 shipped in alpha.16** (close-the-loop). **M3 is complete on
+the integration branch** (export/engraving tail, #245 no-dependency half, #249, #246 scoped
+behavior). M4 (page view) and M5 (chord theory) are next and can run in parallel. Remaining
+M2/M3-adjacent follow-ups: #255 (chord reflow re-anchoring / pickup playback), the capacity
+SSOT #254, full #237 quant migration, full official MusicXML XSD CI, and QA-pass items
+#268–#272.
 
 ## Cross-cutting — testing & CI (continuous, not a phase)
 
@@ -210,7 +223,10 @@ partials #246/#237 — plus QA-pass items #268–#272.
   suite; Lane B Playwright harness runs in CI against **committed linux baselines** (seeded
   via the "Visual regression (Lane B)" dispatch). Both lanes verified to catch a seeded
   regression. See [VISUAL_TESTING.md](VISUAL_TESTING.md).
-- Add **MusicXML 4.0 XSD validation** to CI (with M3 / #246).
+- ✅ **MusicXML structural validation gate** — shipped with M3 in the normal Jest/CI path
+  using `fast-xml-parser` plus semantic checks for duration/staff/backup/order/tuplet/rest
+  invariants. Add the full official **MusicXML 4.0 XSD** bundle to CI as a follow-up
+  hardening layer when the CI image/dependency choice is settled.
 - Ongoing: unit-coverage (#17), E2E harness (#15), hit-detection test robustness
   (#211/#210), keep the theory/geometry oracles green.
 
@@ -220,7 +236,7 @@ partials #246/#237 — plus QA-pass items #268–#272.
 |---|---|---|
 | #242 (invariants) | ✅ done (alpha.15) | Shipped with the #237 integrality guard inside it (capacity/anchoring math); full ×LCM migration still deferred. |
 | #237 (full ×LCM migration) | — (`SCHEMA_VERSION` now at **2**) | Deferred until tuplet-heavy editing demonstrates a concrete bug. Use base ≥ 210, not 105; its migration bumps `SCHEMA_VERSION` to 3. |
-| #245 dotted/secondary beams | — | No #237 dependency; lands in M3. |
+| #245 dotted/secondary beams | ✅ done with M3 | No #237 dependency; mixed-value primary/secondary/partial segments now render from layout data. |
 | #245 tuplet beaming | #237 | Beat-boundary `% beatQuants` is unreliable with non-integer tuplet quants; deferred with #237. |
 | M4 cross-system ties | M2 (#242 tie model) | Page-view tie rendering needs the corrected tie model. |
 | #239 (transpose) | ✅ done (alpha.14) | Key-aware spelling + steps rename + coercion removal shipped. |
@@ -235,9 +251,10 @@ and folds in the promise-gaps:
   #237 guard).
 - Audit **Phase 3** (transpose) → **M2** (#239).
 - Audit **Phase 4** (invariants) → **M2** (#242).
-- Audit **Phase 2** (export) → **M3** — *de-prioritized* because its high-impact items
-  already shipped; only the tail remains.
-- Audit **Phase 5** (engraving) → **M3** (#245 non-tuplet half) + banked beaming.
+- Audit **Phase 2** (export) → **M3** — ✅ tail complete for the scoped exporter defects;
+  official full-XSD CI remains hardening.
+- Audit **Phase 5** (engraving) → **M3** — ✅ #245 non-tuplet half + #249 complete; tuplet
+  beaming still follows #237.
 - Audit **Phase 6** (page view) → **M4**.
 - Audit **Phase 7** (chord theory) → **M5**.
 
@@ -246,7 +263,7 @@ and folds in the promise-gaps:
 ## Verification
 
 This roadmap's load-bearing claims were independently fact-checked against the code
-(2026-06-04; **M1 status updated post-M1 on `dev`**). Confirmed: `SCHEMA_VERSION` is
+(2026-06-04; **M1 status updated post-M1 on `dev`; M3 status updated on the integration branch 2026-06-23**). Confirmed: `SCHEMA_VERSION` is
 stamped by `migrateScore` and was bumped to **2** in alpha.12 so v1 scores re-run the new
 migration steps (#237 unblocked); the export wins above are all present (`<fifths>` is score-level, which
 is correct for the single-key model); `api.play()` now plays the chord track via
@@ -255,4 +272,6 @@ shipped in alpha.13); `setChordDisplay`/`setChordPlayback` are stubs; transpose 
 key-aware with lossless undo (#239 shipped in alpha.14 — `spellPitchInKey`, octave
 coercion removed); and the
 tuplet-grid dependency for #242/#245 is real (partial-tuplet quants are non-integer and
-`getBreakdownOfQuants` drops the remainder), making the integrality guard mandatory.
+`getBreakdownOfQuants` drops the remainder), making the integrality guard mandatory; and
+M3's scoped export/engraving tail is covered by exporter, layout, visual-structure, and
+MusicXML structural validation tests.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,10 +44,13 @@ release now on `dev` / [PR #248](https://github.com/joekotvas/RiffScore/pull/248
   `<divisions>` (LCM of tuplet denominators), grand-staff as one `<part>` with
   `<staves>` + `<backup>`, pickup `implicit="yes"`, score-level `<fifths>`; ABC
   measure-local accidental cancellation (#240, #238, #234).
-- **M3 export/engraving tail** *(Unreleased / pending release)* — MusicXML key mode,
-  whole-measure rests for empty grand-staff staves, slash/extended harmony mapping,
-  stricter note-order/tuplet/rest structural validation, ABC pickup meters/final barline/
-  tuplet chord anchors, key-aware tie layout, and mixed-value secondary/partial beams.
+- **M3 export/engraving tail** *(Unreleased / pending release)* — MusicXML key `<mode>`,
+  whole-measure rests for empty grand-staff staves, richer `<harmony>`/`<degree>` for
+  extended/altered chords (export layer only — display/playback normalization stays open,
+  cluster 7), stricter note-order/tuplet/rest structural validation, ABC pickup-bar meters
+  and fractional-tuplet chord anchors, cross-measure key/stretch-aware tie layout, and
+  mixed-value secondary/partial beams. *(The official MusicXML-4.0-XSD-in-CI gate is not
+  delivered — see M3 below.)*
 - **Transpose lossless undo** — both transpose commands snapshot the pre-image and
   restore verbatim (contract C3).
 - **Migration versioning** — `SCHEMA_VERSION` bumped to **2** so scores saved at v1
@@ -130,27 +133,40 @@ With a trustworthy model, make what gets shared and printed match it exactly.
 
 - ✅ **MusicXML tail** — note child-ordering remains parser-safe; tuplet durations sum to
   `divisions·beats`; #246 empty grand-staff staves emit `<rest measure="yes"/>`; minor
-  keys emit `<mode>`; tuplet bracket notations are primary-note only; slash and extended
-  chord symbols map into richer `<harmony>` / `<degree>` output.
-- ✅ **MusicXML structural validation** — representative real exporter output now runs
-  through a deterministic Jest gate that checks staff duration streams, `<backup>`
-  durations, note child order, tuplet notation placement, and full-measure rests. The
-  committed reduced XSD fixture remains documented; wiring the full official MusicXML
-  4.0 XSD bundle into CI is now a hardening follow-up, not a blocker for the M3 defects
-  above.
-- ✅ **ABC tail** — quintuplet ratios, final barline `|]`, pickup-meter annotation, and
-  fractional tuplet chord anchors are covered by exporter tests.
+  keys emit `<mode>`; tuplet bracket notations are primary-note only; extended/altered
+  chords (9/11/13, add/alter tones) map into richer `<harmony>` / `<degree>` output.
+  *(Export layer only — the internal chord-symbol normalization and slash-bass voicing
+  are still wrong on screen and in playback (cluster 7, LIVE). Slash `<bass>` **export**
+  predates M3 and is unchanged here.)*
+- ✅ **MusicXML structural validation** — representative real exporter output, **including a
+  tuplet-containing score**, now runs through a deterministic Jest gate that checks staff
+  duration streams, `<backup>` durations, note child order, tuplet notation placement, and
+  full-measure rests. This catches the *musical-corruption* defect class (e.g. duration-sum
+  errors an XSD would happily pass) better than a schema check.
+- ⏳ **Official MusicXML 4.0 XSD validation in CI** — *still owed (audit Phase 2 gate, not
+  delivered by M3).* The audit requires validating a representative export against the
+  official XSD via `xmllint` in CI; the committed reduced `.xsd` fixture is documentation
+  only and is wired to no test. The structural gate above substitutes for the corruption
+  class but does **not** discharge this verification requirement.
+- ✅ **ABC tail** — pickup bars emit their own temporary `[M:n/d]` meter and chord symbols
+  on fractional tuplet positions are no longer dropped (shared chord-anchor quantizer).
+  *(Quintuplet ratios and the final barline `|]` shipped earlier in alpha.16, not M3.)*
 - ✅ **Beaming sub-grouping #245 (the no-dependency half)** — dotted-rhythm grouping and
   secondary/partial beam segments now render from layout data (for example 8th+16th+16th
   and dotted-8th+16th). *The tuplet-beaming half of #245 depends on #237 and remains
-  deferred with it.*
-- ✅ **Tie layout key (#249)** — cross-measure tie endpoint X now uses the same
-  key-aware/stretched measure layout as rendered noteheads, including direct Measure
-  fallback paths.
+  deferred with it; mean-Y stem direction, the 45° `MAX_SLOPE` clamp, and beamed-over-rests
+  (audit finding #9 siblings) are out of scope and stay LIVE.*
+- ✅ **Tie layout key (#249)** — cross-measure tie endpoint X now uses the same key-aware
+  measure layout as rendered noteheads, in both the unstretched and justified
+  (stretch ≠ 1.0) paths, regression-tested at tie-X == notehead-X. *(Cross-SYSTEM tie arcs
+  — #270 — are separate and still open: Tie.tsx's split-arc props stay unwired.)*
 
-**Done when:** MusicXML/ABC exports and on-canvas engraving agree for the M3 defect
-classes, and representative exports are covered by structural CI tests. — ✅ **Met**
-for the scoped M3 tail; full official-XSD CI remains a follow-up hardening item.
+**Done when:** exports are internally consistent (durations sum, DTD child order,
+tuplet/rest placement) under structural CI tests, tie endpoints match noteheads, and beams
+render from layout data. — ✅ **Met** for the scoped M3 tail. Two verification items remain
+explicitly open: the audit's official-MusicXML-4.0-XSD-in-CI gate (above), and true
+export↔render *round-trip* agreement, which is untestable until an import path exists
+(there is none today).
 
 ---
 

--- a/src/__tests__/beaming.compoundMeter.test.ts
+++ b/src/__tests__/beaming.compoundMeter.test.ts
@@ -211,6 +211,40 @@ describe('4/4 regression (behavior must be identical to before #241)', () => {
     expect(groups).toEqual([['e1', 'e2', 'e3', 'e4']]);
   });
 
+  test('mixed eighth + sixteenths share a primary beam with a shorter secondary beam (#245)', () => {
+    const events: ScoreEvent[] = [
+      { id: 'e1', duration: 'eighth', dotted: false, notes: [{ id: 'n1', pitch: 'C4' }] },
+      { id: 'e2', duration: 'sixteenth', dotted: false, notes: [{ id: 'n2', pitch: 'D4' }] },
+      { id: 'e3', duration: 'sixteenth', dotted: false, notes: [{ id: 'n3', pitch: 'E4' }] },
+    ];
+    const [group] = calculateBeamingGroups(events, makePositions(events), 'treble', '4/4');
+
+    expect(group.ids).toEqual(['e1', 'e2', 'e3']);
+    const primary = group.segments?.filter((segment) => segment.level === 1) ?? [];
+    const secondary = group.segments?.filter((segment) => segment.level === 2) ?? [];
+
+    expect(primary).toHaveLength(1);
+    expect(secondary).toHaveLength(1);
+    expect(secondary[0].startX).toBeGreaterThan(primary[0].startX);
+    expect(secondary[0].endX).toBeCloseTo(primary[0].endX, 1);
+  });
+
+  test('dotted eighth + sixteenth beams together with a partial secondary beamlet (#245)', () => {
+    const events: ScoreEvent[] = [
+      { id: 'e1', duration: 'eighth', dotted: true, notes: [{ id: 'n1', pitch: 'C4' }] },
+      { id: 'e2', duration: 'sixteenth', dotted: false, notes: [{ id: 'n2', pitch: 'D4' }] },
+    ];
+    const [group] = calculateBeamingGroups(events, makePositions(events), 'treble', '4/4');
+    const primary = group.segments?.find((segment) => segment.level === 1);
+    const secondary = group.segments?.find((segment) => segment.level === 2);
+
+    expect(group.ids).toEqual(['e1', 'e2']);
+    expect(primary).toBeDefined();
+    expect(secondary).toBeDefined();
+    expect(secondary!.endX - secondary!.startX).toBeLessThan(primary!.endX - primary!.startX);
+    expect(secondary!.startX).toBeGreaterThan(primary!.startX);
+  });
+
   test('quarter note breaks the beam (no group spanning the rest of the beat)', () => {
     const events: ScoreEvent[] = [
       { id: 'e1', duration: 'eighth', dotted: false, notes: [{ id: 'n1', pitch: 'C4' }] },

--- a/src/__tests__/beaming.compoundMeter.test.ts
+++ b/src/__tests__/beaming.compoundMeter.test.ts
@@ -245,6 +245,20 @@ describe('4/4 regression (behavior must be identical to before #241)', () => {
     expect(secondary!.startX).toBeGreaterThan(primary!.startX);
   });
 
+  test('mixed values do not beam across a quarter-beat boundary', () => {
+    const events: ScoreEvent[] = [
+      { id: 'e1', duration: 'eighth', dotted: false, notes: [{ id: 'n1', pitch: 'C4' }] },
+      { id: 's1', duration: 'sixteenth', dotted: false, notes: [{ id: 'n2', pitch: 'D4' }] },
+      { id: 'e2', duration: 'eighth', dotted: false, notes: [{ id: 'n3', pitch: 'E4' }] },
+      { id: 's2', duration: 'sixteenth', dotted: false, notes: [{ id: 'n4', pitch: 'F4' }] },
+    ];
+    const groups = groupIds(events, '4/4');
+
+    // e2 starts inside beat 1 but overruns the quarter boundary; it must not
+    // glue the first beat's beam group to the next beat.
+    expect(groups).toEqual([['e1', 's1']]);
+  });
+
   test('quarter note breaks the beam (no group spanning the rest of the beat)', () => {
     const events: ScoreEvent[] = [
       { id: 'e1', duration: 'eighth', dotted: false, notes: [{ id: 'n1', pitch: 'C4' }] },

--- a/src/__tests__/components/Canvas/MeasureFallbackLayout.test.tsx
+++ b/src/__tests__/components/Canvas/MeasureFallbackLayout.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '@/context/ThemeContext';
+import Measure from '@/components/Canvas/Measure';
+import { CONFIG } from '@/config';
+import { createDefaultSelection, ScoreEvent } from '@/types';
+
+const eighths = (count: number): ScoreEvent[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `e${i}`,
+    duration: 'eighth',
+    dotted: false,
+    notes: [{ id: `n${i}`, pitch: 'B4' }],
+  }));
+
+describe('Measure fallback layout', () => {
+  it('uses the real time signature for stretched fallback beaming (#245)', () => {
+    const interaction = {
+      selection: createDefaultSelection(),
+      previewNote: null,
+      activeDuration: 'quarter',
+      isDotted: false,
+      modifierHeld: false,
+      isDragging: false,
+      onAddNote: jest.fn(),
+      onSelectNote: jest.fn(),
+      onDragStart: jest.fn(),
+      onHover: jest.fn(),
+    };
+
+    const { container } = render(
+      <ThemeProvider>
+        <svg>
+          <Measure
+            measureIndex={0}
+            measureData={{ id: 'm0', events: eighths(6) }}
+            startX={0}
+            isLast
+            stretchFactor={1.2}
+            layout={{
+              scale: 1,
+              baseY: CONFIG.baseY,
+              clef: 'treble',
+              keySignature: 'C',
+              timeSignature: '6/8',
+              staffIndex: 0,
+              verticalOffset: 0,
+            }}
+            interaction={interaction}
+          />
+        </svg>
+      </ThemeProvider>
+    );
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelectorAll('.beam-group')).toHaveLength(2);
+  });
+});

--- a/src/__tests__/exporters/abcAccidentals.test.ts
+++ b/src/__tests__/exporters/abcAccidentals.test.ts
@@ -243,6 +243,32 @@ describe('ABC tuplet ratios use the explicit (p:q:r form', () => {
 });
 
 // ===========================================================================
+// Chord anchors inside tuplets
+// ===========================================================================
+
+describe('ABC chord annotations at fractional tuplet anchors', () => {
+  it('emits a chord placed on the second member of an eighth-note triplet', () => {
+    const events: ScoreEvent[] = [0, 1, 2].map((i) => ({
+      id: `t${i}`,
+      duration: 'eighth',
+      dotted: false,
+      notes: [{ id: `tn${i}`, pitch: ['C4', 'D4', 'E4'][i] }],
+      tuplet: { ratio: [3, 2], groupSize: 3, position: i, baseDuration: 'eighth' },
+    }));
+    const score = {
+      ...buildScore([
+        ...events,
+        { id: 'pad', duration: 'half', dotted: true, notes: [{ id: 'padn', pitch: 'G4' }] },
+      ]),
+      chordTrack: [{ id: 'chord-1', measure: 0, quant: 5.333, symbol: 'G7' }],
+    };
+
+    const body = getVoiceBody(generateABC(score, 120));
+    expect(body).toContain('"G7"D');
+  });
+});
+
+// ===========================================================================
 // Ties: hyphen after the complete note token
 // ===========================================================================
 
@@ -296,5 +322,46 @@ describe('ABC final barline', () => {
     const abc = generateABC(buildScore([quarter('e1', 'C4')]), 120);
     const body = getVoiceBody(abc);
     expect(body.trim().endsWith('|]')).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Pickup/anacrusis
+// ===========================================================================
+
+describe('ABC pickup meter marking', () => {
+  it('marks a leading pickup with an inline short meter and restores the score meter', () => {
+    const score = buildMultiMeasureScore([
+      [{ id: 'pickup', duration: 'quarter', dotted: false, notes: [{ id: 'pickup-n', pitch: 'G4' }] }],
+      [
+        quarter('a', 'C5'),
+        quarter('b', 'D5'),
+        quarter('c', 'E5'),
+        quarter('d', 'F5'),
+      ],
+    ]);
+    score.staves[0].measures[0].isPickup = true;
+
+    const body = getVoiceBody(generateABC(score, 120));
+    expect(body).toContain('[M:1/4]G');
+    expect(body).toContain('| [M:4/4]c');
+  });
+
+  it('reduces dotted pickup lengths to the matching inline meter', () => {
+    const score = buildMultiMeasureScore([
+      [
+        {
+          id: 'pickup',
+          duration: 'quarter',
+          dotted: true,
+          notes: [{ id: 'pickup-n', pitch: 'G4' }],
+        },
+      ],
+      [quarter('a', 'C5')],
+    ]);
+    score.staves[0].measures[0].isPickup = true;
+
+    const body = getVoiceBody(generateABC(score, 120));
+    expect(body).toContain('[M:3/8]G3/2');
   });
 });

--- a/src/__tests__/exporters/musicXmlExporter.test.ts
+++ b/src/__tests__/exporters/musicXmlExporter.test.ts
@@ -140,6 +140,20 @@ describe('MusicXML Clef Export', () => {
   });
 });
 
+describe('MusicXML Key Export', () => {
+  it.each([
+    ['C', 'major'],
+    ['Am', 'minor'],
+    ['Em', 'minor'],
+  ])('exports %s with an explicit <mode>%s</mode>', (keySignature, mode) => {
+    const score = { ...createScoreWithClef('treble'), keySignature };
+    const xml = generateMusicXML(score);
+
+    expect(xml).toContain('<key>');
+    expect(xml).toContain(`<mode>${mode}</mode>`);
+  });
+});
+
 describe('MusicXML Chord Symbol Export', () => {
   /**
    * Create a score with chord symbols in the chord track
@@ -200,6 +214,41 @@ describe('MusicXML Chord Symbol Export', () => {
 
     expect(xml).toContain('<root-step>C</root-step>');
     expect(xml).toContain('<kind>major-seventh</kind>');
+  });
+
+  it.each([
+    ['Cmaj', 'major'],
+    ['Cmaj9', 'major-ninth'],
+    ['Cmaj11', 'major-11th'],
+    ['Cmaj13', 'major-13th'],
+    ['C9', 'dominant-ninth'],
+    ['C11', 'dominant-11th'],
+    ['C13', 'dominant-13th'],
+    ['C6', 'major-sixth'],
+    ['Cm6', 'minor-sixth'],
+  ])('exports %s with kind %s', (symbol, kind) => {
+    const score = createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol }]);
+    const xml = generateMusicXML(score);
+
+    expect(xml).toContain(`<kind>${kind}</kind>`);
+  });
+
+  it('exports add/altered chord degrees instead of dropping them', () => {
+    const add = generateMusicXML(
+      createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Cadd9' }])
+    );
+    expect(add).toContain('<kind>major</kind>');
+    expect(add).toContain('<degree-value>9</degree-value>');
+    expect(add).toContain('<degree-alter>0</degree-alter>');
+    expect(add).toContain('<degree-type>add</degree-type>');
+
+    const altered = generateMusicXML(
+      createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'C7b9' }])
+    );
+    expect(altered).toContain('<kind>dominant</kind>');
+    expect(altered).toContain('<degree-value>9</degree-value>');
+    expect(altered).toContain('<degree-alter>-1</degree-alter>');
+    expect(altered).toContain('<degree-type>alter</degree-type>');
   });
 
   it('exports minor seventh chord correctly', () => {
@@ -300,6 +349,71 @@ describe('MusicXML Chord Symbol Export', () => {
     const harmonyIndex = xml.indexOf('<harmony>');
     const secondNoteIndex = xml.indexOf('<step>E</step>'); // E4 is the second note
     expect(harmonyIndex).toBeLessThan(secondNoteIndex);
+  });
+
+  it('places harmony at a fractional tuplet anchor', () => {
+    const tripletEvents: Score['staves'][0]['measures'][0]['events'] = [0, 1, 2].map((i) => ({
+      id: `t${i}`,
+      duration: 'eighth',
+      dotted: false,
+      notes: [{ id: `tn${i}`, pitch: ['C4', 'D4', 'E4'][i] }],
+      tuplet: { ratio: [3, 2], groupSize: 3, position: i, baseDuration: 'eighth' },
+    }));
+    const score = createScoreWithChords(
+      [{ id: 'chord-1', measure: 0, quant: 5.333, symbol: 'G7' }],
+      [
+        ...tripletEvents,
+        { id: 'pad', duration: 'half', dotted: true, notes: [{ id: 'padn', pitch: 'G4' }] },
+      ]
+    );
+    const xml = generateMusicXML(score);
+
+    const harmonyIndex = xml.indexOf('<harmony>');
+    const secondTupletNoteIndex = xml.indexOf('<step>D</step>');
+    expect(harmonyIndex).toBeGreaterThan(-1);
+    expect(harmonyIndex).toBeLessThan(secondTupletNoteIndex);
+  });
+
+  it('emits tuplet notation only on the primary note of a chord tuplet member', () => {
+    const events: Score['staves'][0]['measures'][0]['events'] = [
+      {
+        id: 't0',
+        duration: 'eighth',
+        dotted: false,
+        notes: [
+          { id: 'n0a', pitch: 'C4' },
+          { id: 'n0b', pitch: 'E4' },
+        ],
+        tuplet: { ratio: [3, 2], groupSize: 3, position: 0, baseDuration: 'eighth' },
+      },
+      {
+        id: 't1',
+        duration: 'eighth',
+        dotted: false,
+        notes: [{ id: 'n1', pitch: 'D4' }],
+        tuplet: { ratio: [3, 2], groupSize: 3, position: 1, baseDuration: 'eighth' },
+      },
+      {
+        id: 't2',
+        duration: 'eighth',
+        dotted: false,
+        notes: [
+          { id: 'n2a', pitch: 'E4' },
+          { id: 'n2b', pitch: 'G4' },
+        ],
+        tuplet: { ratio: [3, 2], groupSize: 3, position: 2, baseDuration: 'eighth' },
+      },
+      { id: 'pad', duration: 'half', dotted: true, notes: [{ id: 'padn', pitch: 'C5' }] },
+    ];
+    const xml = generateMusicXML(createScoreWithChords([], events));
+
+    expect(xml.match(/<tuplet type="start"/g)).toHaveLength(1);
+    expect(xml.match(/<tuplet type="stop"/g)).toHaveLength(1);
+    const chordNoteBlocks = [...xml.matchAll(/<note>([\s\S]*?)<\/note>/g)]
+      .map((m) => m[1])
+      .filter((block) => block.includes('<chord/>'));
+    expect(chordNoteBlocks).toHaveLength(2);
+    chordNoteBlocks.forEach((block) => expect(block).not.toContain('<tuplet '));
   });
 
   it('exports multiple chords at different positions', () => {
@@ -711,6 +825,27 @@ describe('MusicXML Grand-Staff Export (one part, <staves>/<backup>)', () => {
     expect(xml).toMatch(
       new RegExp(`<backup>\\s*<duration>${expectedBackup}</duration>\\s*</backup>`)
     );
+  });
+
+  it('emits a full-measure rest for an empty grand-staff staff', () => {
+    const score = createGrandStaffScore({
+      staves: [
+        createGrandStaffScore().staves[0],
+        {
+          id: 'staff-bass',
+          clef: 'bass',
+          keySignature: 'C',
+          measures: [{ id: 'm1-b', events: [] }],
+        },
+      ],
+    });
+    const xml = generateMusicXML(score);
+    const parsed = parseMusicXml(xml);
+    const divisions = parsed.parts[0].measures[0].divisions;
+
+    expect(xml).toContain('<rest measure="yes"/>');
+    expect(xml).toContain('<staff>2</staff>');
+    expect(xml).toMatch(new RegExp(`<rest measure="yes"/>\\s*<duration>${divisions * 4}</duration>`));
   });
 
   it('the <backup> appears between the staff-1 note and the staff-2 note', () => {

--- a/src/__tests__/exporters/musicXmlExporter.test.ts
+++ b/src/__tests__/exporters/musicXmlExporter.test.ts
@@ -10,6 +10,7 @@ import {
   parseMusicXml,
   checkDurationSums,
   allDurationsIntegral,
+  validateMusicXmlStructure,
 } from '../fixtures/musicXmlStructure';
 
 /**
@@ -249,6 +250,26 @@ describe('MusicXML Chord Symbol Export', () => {
     expect(altered).toContain('<degree-value>9</degree-value>');
     expect(altered).toContain('<degree-alter>-1</degree-alter>');
     expect(altered).toContain('<degree-type>alter</degree-type>');
+  });
+
+  it('does not duplicate degrees already represented by the matched chord kind', () => {
+    const xml = generateMusicXML(
+      createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'Bm7b5' }])
+    );
+
+    expect(xml).toContain('<kind>half-diminished</kind>');
+    expect(xml).not.toContain('<degree-value>5</degree-value>');
+  });
+
+  it('preserves the dominant seventh meaning in 7sus4 chords', () => {
+    const xml = generateMusicXML(
+      createScoreWithChords([{ id: 'chord-1', measure: 0, quant: 0, symbol: 'C7sus4' }])
+    );
+
+    expect(xml).toContain('<kind>dominant</kind>');
+    expect(xml).toContain('<degree-value>4</degree-value>');
+    expect(xml).toContain('<degree-alter>0</degree-alter>');
+    expect(xml).toContain('<degree-type>add</degree-type>');
   });
 
   it('exports minor seventh chord correctly', () => {
@@ -845,7 +866,44 @@ describe('MusicXML Grand-Staff Export (one part, <staves>/<backup>)', () => {
 
     expect(xml).toContain('<rest measure="yes"/>');
     expect(xml).toContain('<staff>2</staff>');
-    expect(xml).toMatch(new RegExp(`<rest measure="yes"/>\\s*<duration>${divisions * 4}</duration>`));
+    expect(xml).toMatch(
+      new RegExp(`<rest measure="yes"/>\\s*<duration>${divisions * 4}</duration>`)
+    );
+  });
+
+  it('marks authored whole-bar rests as measure rests so structural validation accepts them', () => {
+    const score: Score = {
+      title: 'Authored Rest',
+      timeSignature: '4/4',
+      keySignature: 'C',
+      bpm: 120,
+      staves: [
+        {
+          id: 'staff-1',
+          clef: 'treble',
+          keySignature: 'C',
+          measures: [
+            {
+              id: 'm1',
+              events: [
+                {
+                  id: 'rest-1',
+                  duration: 'whole',
+                  dotted: false,
+                  isRest: true,
+                  notes: [{ id: 'rest-note-1', pitch: null, isRest: true }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const xml = generateMusicXML(score);
+    const issues = validateMusicXmlStructure(xml);
+
+    expect(xml).toContain('<rest measure="yes"/>');
+    expect(issues).toEqual([]);
   });
 
   it('the <backup> appears between the staff-1 note and the staff-2 note', () => {
@@ -918,9 +976,7 @@ describe('MusicXML Grand-Staff Export (one part, <staves>/<backup>)', () => {
     // Combined: 8 quarter notes => sum is 2 * (divisions*4).
     const divisions = parsed.parts[0].measures[0].divisions;
     const measure = parsed.parts[0].measures[0];
-    const total = measure.notes
-      .filter((n) => !n.isChord)
-      .reduce((s, n) => s + n.duration, 0);
+    const total = measure.notes.filter((n) => !n.isChord).reduce((s, n) => s + n.duration, 0);
     expect(total).toBe(2 * divisions * 4);
     expect(allDurationsIntegral(parsed)).toBe(true);
   });
@@ -1058,7 +1114,12 @@ describe('MusicXML Pickup / Anacrusis Export (implicit measure 0)', () => {
               id: 'm0-t',
               isPickup: true,
               events: [
-                { id: 'pt', duration: 'quarter', dotted: false, notes: [{ id: 'ptn', pitch: 'G4' }] },
+                {
+                  id: 'pt',
+                  duration: 'quarter',
+                  dotted: false,
+                  notes: [{ id: 'ptn', pitch: 'G4' }],
+                },
               ],
             },
             {
@@ -1078,7 +1139,12 @@ describe('MusicXML Pickup / Anacrusis Export (implicit measure 0)', () => {
               id: 'm0-b',
               isPickup: true,
               events: [
-                { id: 'pb', duration: 'quarter', dotted: false, notes: [{ id: 'pbn', pitch: 'G2' }] },
+                {
+                  id: 'pb',
+                  duration: 'quarter',
+                  dotted: false,
+                  notes: [{ id: 'pbn', pitch: 'G2' }],
+                },
               ],
             },
             {
@@ -1101,4 +1167,81 @@ describe('MusicXML Pickup / Anacrusis Export (implicit measure 0)', () => {
     // One backup per measure (pickup + full) => two backups.
     expect(xml.match(/<backup>/g)).toHaveLength(2);
   });
+
+  it.each(['missing', 'empty'] as const)(
+    'emits pickup-length measure rests for %s lower-staff pickup measures',
+    (lowerPickupShape) => {
+      const lowerFullMeasure = {
+        id: 'm1-b',
+        events: [
+          {
+            id: 'fb',
+            duration: 'whole',
+            dotted: false,
+            notes: [{ id: 'fbn', pitch: 'C3' }],
+          },
+        ],
+      };
+      const lowerMeasures = [] as Score['staves'][0]['measures'];
+      if (lowerPickupShape === 'empty') {
+        lowerMeasures[0] = { id: 'm0-b', isPickup: true, events: [] };
+      }
+      lowerMeasures[1] = lowerFullMeasure;
+      const score: Score = {
+        title: 'Pickup Grand Empty Lower',
+        timeSignature: '4/4',
+        keySignature: 'C',
+        bpm: 120,
+        staves: [
+          {
+            id: 'staff-treble',
+            clef: 'treble',
+            keySignature: 'C',
+            measures: [
+              {
+                id: 'm0-t',
+                isPickup: true,
+                events: [
+                  {
+                    id: 'pt',
+                    duration: 'quarter',
+                    dotted: false,
+                    notes: [{ id: 'ptn', pitch: 'G4' }],
+                  },
+                ],
+              },
+              {
+                id: 'm1-t',
+                events: [
+                  {
+                    id: 'ft',
+                    duration: 'whole',
+                    dotted: false,
+                    notes: [{ id: 'ftn', pitch: 'C4' }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: 'staff-bass',
+            clef: 'bass',
+            keySignature: 'C',
+            measures: lowerMeasures,
+          },
+        ],
+      };
+      const xml = generateMusicXML(score);
+      const parsed = parseMusicXml(xml);
+      const pickup = parsed.parts[0].measures[0];
+      const lowerRest = pickup.notes.find((note) => note.isRest && note.staff === 2);
+
+      expect(pickup.isImplicit).toBe(true);
+      expect(lowerRest).toBeDefined();
+      expect(lowerRest?.restMeasure).toBe(true);
+      expect(lowerRest?.duration).toBe(pickup.divisions);
+      expect(pickup.backups[0]?.duration).toBe(pickup.divisions);
+      expect(validateMusicXmlStructure(xml)).toEqual([]);
+    }
+  );
 });

--- a/src/__tests__/exporters/musicXmlStructuralValidation.test.ts
+++ b/src/__tests__/exporters/musicXmlStructuralValidation.test.ts
@@ -1,0 +1,82 @@
+import { generateMusicXML } from '@/exporters/musicXmlExporter';
+import { Score, ScoreEvent } from '@/types';
+import { validateMusicXmlStructure } from '../fixtures/musicXmlStructure';
+
+const q = (id: string, pitch: string): ScoreEvent => ({
+  id,
+  duration: 'quarter',
+  dotted: false,
+  notes: [{ id: `${id}n`, pitch }],
+});
+
+const representativeSingleStaffScore = (): Score => ({
+  title: 'Structural',
+  timeSignature: '4/4',
+  keySignature: 'C',
+  bpm: 120,
+  staves: [
+    {
+      id: 'staff-1',
+      clef: 'treble',
+      keySignature: 'C',
+      measures: [
+        {
+          id: 'm1',
+          events: [
+            {
+              id: 'chord',
+              duration: 'quarter',
+              dotted: false,
+              notes: [
+                { id: 'c', pitch: 'C4' },
+                { id: 'e', pitch: 'E4' },
+              ],
+            },
+            q('d', 'D4'),
+            q('e', 'E4'),
+            q('f', 'F4'),
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const representativeGrandStaffScore = (): Score => ({
+  title: 'Structural Grand',
+  timeSignature: '4/4',
+  keySignature: 'C',
+  bpm: 120,
+  staves: [
+    {
+      id: 'treble',
+      clef: 'treble',
+      keySignature: 'C',
+      measures: [
+        { id: 'm1-t', events: [q('t1', 'C4'), q('t2', 'D4'), q('t3', 'E4'), q('t4', 'F4')] },
+      ],
+    },
+    {
+      id: 'bass',
+      clef: 'bass',
+      keySignature: 'C',
+      measures: [
+        { id: 'm1-b', events: [q('b1', 'C3'), q('b2', 'D3'), q('b3', 'E3'), q('b4', 'F3')] },
+      ],
+    },
+  ],
+});
+
+describe('MusicXML structural validator on real exporter output', () => {
+  it('accepts a representative single-staff export with a chord event', () => {
+    expect(validateMusicXmlStructure(generateMusicXML(representativeSingleStaffScore()))).toEqual(
+      []
+    );
+  });
+
+  it('accepts a representative grand-staff export with staff tags and backups', () => {
+    expect(validateMusicXmlStructure(generateMusicXML(representativeGrandStaffScore()))).toEqual(
+      []
+    );
+  });
+});

--- a/src/__tests__/exporters/musicXmlStructuralValidation.test.ts
+++ b/src/__tests__/exporters/musicXmlStructuralValidation.test.ts
@@ -1,6 +1,11 @@
 import { generateMusicXML } from '@/exporters/musicXmlExporter';
 import { Score, ScoreEvent } from '@/types';
-import { validateMusicXmlStructure } from '../fixtures/musicXmlStructure';
+import {
+  validateMusicXmlStructure,
+  allDurationsIntegral,
+  parseMusicXml,
+  checkTupletNotationPlacement,
+} from '../fixtures/musicXmlStructure';
 
 const q = (id: string, pitch: string): ScoreEvent => ({
   id,
@@ -67,6 +72,54 @@ const representativeGrandStaffScore = (): Score => ({
   ],
 });
 
+const tripletEighth = (
+  id: string,
+  position: number,
+  notes: ScoreEvent['notes']
+): ScoreEvent => ({
+  id,
+  duration: 'eighth',
+  dotted: false,
+  tuplet: { ratio: [3, 2], groupSize: 3, position, baseDuration: 'eighth', id: 'T1' },
+  notes,
+});
+
+// A 4/4 bar whose first beat is an eighth-note triplet — with the FIRST triplet member a
+// chord — followed by three quarters. This exercises the defect class the structural
+// validator exists for, end-to-end through generateMusicXML (not against hand-authored
+// XML): content-derived <divisions> must keep the triplet <duration>s integral and summing
+// to the bar (the old Math.floor bug summed to 15/16 of a beat), and the tuplet bracket
+// must appear once on the primary note only — never duplicated on the chord member (M3 #245).
+const representativeTupletScore = (): Score => ({
+  title: 'Structural Tuplet',
+  timeSignature: '4/4',
+  keySignature: 'C',
+  bpm: 120,
+  staves: [
+    {
+      id: 'staff-1',
+      clef: 'treble',
+      keySignature: 'C',
+      measures: [
+        {
+          id: 'm1',
+          events: [
+            tripletEighth('tr0', 0, [
+              { id: 'tr0c', pitch: 'C4' },
+              { id: 'tr0e', pitch: 'E4' },
+            ]),
+            tripletEighth('tr1', 1, [{ id: 'tr1n', pitch: 'D4' }]),
+            tripletEighth('tr2', 2, [{ id: 'tr2n', pitch: 'E4' }]),
+            q('q2', 'F4'),
+            q('q3', 'G4'),
+            q('q4', 'A4'),
+          ],
+        },
+      ],
+    },
+  ],
+});
+
 describe('MusicXML structural validator on real exporter output', () => {
   it('accepts a representative single-staff export with a chord event', () => {
     expect(validateMusicXmlStructure(generateMusicXML(representativeSingleStaffScore()))).toEqual(
@@ -78,5 +131,22 @@ describe('MusicXML structural validator on real exporter output', () => {
     expect(validateMusicXmlStructure(generateMusicXML(representativeGrandStaffScore()))).toEqual(
       []
     );
+  });
+
+  it('accepts a tuplet-containing export with integral durations that sum to the bar', () => {
+    const xml = generateMusicXML(representativeTupletScore());
+    expect(validateMusicXmlStructure(xml)).toEqual([]);
+    // Guards the headline corruption class: every <duration> is a positive integer
+    // (no Math.floor truncation) once <divisions> is content-derived.
+    expect(allDurationsIntegral(parseMusicXml(xml))).toBe(true);
+  });
+
+  it('emits the tuplet bracket once on the primary note, never on a chord member', () => {
+    const xml = generateMusicXML(representativeTupletScore());
+    // Exactly one start + one stop bracket for the single triplet group — not dropped
+    // because the primary note is a chord, and not duplicated onto the chord member.
+    expect((xml.match(/<tuplet type="start"/g) ?? []).length).toBe(1);
+    expect((xml.match(/<tuplet type="stop"/g) ?? []).length).toBe(1);
+    expect(checkTupletNotationPlacement(parseMusicXml(xml))).toEqual([]);
   });
 });

--- a/src/__tests__/fixtures/musicXmlStructure.ts
+++ b/src/__tests__/fixtures/musicXmlStructure.ts
@@ -22,7 +22,13 @@ const parser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '@_',
   // Force arrays for repeatable elements so single/many are handled uniformly.
-  isArray: (name) => ['part', 'measure', 'note', 'score-part'].includes(name),
+  isArray: (name) => ['part', 'measure', 'note', 'score-part', 'backup', 'forward'].includes(name),
+});
+
+const orderedParser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  preserveOrder: true,
 });
 
 export interface ParsedNote {
@@ -30,19 +36,31 @@ export interface ParsedNote {
   isChord: boolean;
   /** Integer divisions; NaN if absent (a structural error worth surfacing). */
   duration: number;
+  staff?: number;
+  restMeasure?: boolean;
+  tupletNotationTypes: string[];
   step?: string;
   octave?: number;
   alter?: number;
   type?: string;
 }
 
+export interface ParsedBackup {
+  /** Integer divisions; NaN if absent (a structural error worth surfacing). */
+  duration: number;
+}
+
 export interface ParsedMeasure {
   number: number;
+  isImplicit: boolean;
   /** divisions declared in <attributes>, inherited from the first measure that sets it. */
   divisions: number;
+  /** number of staves declared in <attributes>, inherited like MusicXML attributes. */
+  staves: number;
   beats?: number;
   beatType?: number;
   notes: ParsedNote[];
+  backups: ParsedBackup[];
 }
 
 export interface ParsedPart {
@@ -58,6 +76,25 @@ export interface ParsedScore {
 function asArray<T>(v: T | T[] | undefined): T[] {
   if (v === undefined) return [];
   return Array.isArray(v) ? v : [v];
+}
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return v !== null && typeof v === 'object' ? (v as Record<string, unknown>) : undefined;
+}
+
+function childNumber(node: Record<string, unknown> | undefined, child: string): number {
+  if (!node || node[child] === undefined) return NaN;
+  return Number(node[child]);
+}
+
+function tupletNotationTypes(note: Record<string, unknown>): string[] {
+  return asArray<Record<string, unknown>>(
+    note.notations as Record<string, unknown> | Record<string, unknown>[] | undefined
+  ).flatMap((notations) =>
+    asArray<Record<string, unknown>>(
+      notations.tuplet as Record<string, unknown> | Record<string, unknown>[] | undefined
+    ).map((tuplet) => String(tuplet['@_type'] ?? ''))
+  );
 }
 
 /**
@@ -76,6 +113,9 @@ export function parseMusicXml(xml: string): ParsedScore {
     root.part as Record<string, unknown> | Record<string, unknown>[]
   ).map((part) => {
     let divisions = NaN;
+    let staves = 1;
+    let beats: number | undefined;
+    let beatType: number | undefined;
     const measures: ParsedMeasure[] = asArray<Record<string, unknown>>(
       part.measure as Record<string, unknown> | Record<string, unknown>[]
     ).map((measure) => {
@@ -83,8 +123,9 @@ export function parseMusicXml(xml: string): ParsedScore {
       if (attributes && attributes.divisions !== undefined) {
         divisions = Number(attributes.divisions);
       }
-      let beats: number | undefined;
-      let beatType: number | undefined;
+      if (attributes && attributes.staves !== undefined) {
+        staves = Number(attributes.staves);
+      }
       const time = attributes?.time as Record<string, unknown> | undefined;
       if (time) {
         beats = Number(time.beats);
@@ -95,10 +136,14 @@ export function parseMusicXml(xml: string): ParsedScore {
         measure.note as Record<string, unknown> | Record<string, unknown>[]
       ).map((note) => {
         const pitch = note.pitch as Record<string, unknown> | undefined;
+        const rest = asRecord(note.rest);
         return {
           isRest: note.rest !== undefined,
           isChord: note.chord !== undefined,
           duration: note.duration === undefined ? NaN : Number(note.duration),
+          staff: note.staff === undefined ? undefined : Number(note.staff),
+          restMeasure: rest?.['@_measure'] === 'yes',
+          tupletNotationTypes: tupletNotationTypes(note),
           step: pitch?.step as string | undefined,
           octave: pitch?.octave === undefined ? undefined : Number(pitch.octave),
           alter: pitch?.alter === undefined ? undefined : Number(pitch.alter),
@@ -106,12 +151,19 @@ export function parseMusicXml(xml: string): ParsedScore {
         };
       });
 
+      const backups: ParsedBackup[] = asArray<Record<string, unknown>>(
+        measure.backup as Record<string, unknown> | Record<string, unknown>[] | undefined
+      ).map((backup) => ({ duration: childNumber(backup, 'duration') }));
+
       return {
         number: Number(measure['@_number']),
+        isImplicit: measure['@_implicit'] === 'yes',
         divisions,
+        staves,
         beats,
         beatType,
         notes,
+        backups,
       };
     });
 
@@ -179,8 +231,340 @@ export function checkDurationSums(score: ParsedScore): DurationSumIssue[] {
 /** True if every <duration> in the document is a positive integer (MusicXML requires integers). */
 export function allDurationsIntegral(score: ParsedScore): boolean {
   return score.parts.every((p) =>
-    p.measures.every((m) =>
-      m.notes.every((n) => Number.isInteger(n.duration) && n.duration > 0)
+    p.measures.every(
+      (m) =>
+        m.notes.every((n) => Number.isInteger(n.duration) && n.duration > 0) &&
+        m.backups.every((b) => Number.isInteger(b.duration) && b.duration > 0)
     )
   );
+}
+
+export interface StaffDurationIssue {
+  partId: string;
+  measureNumber: number;
+  staffNumber: number;
+  expected: number;
+  actual: number;
+  reason: 'missing-staff-tag' | 'missing-staff' | 'duration-mismatch' | 'pickup-mismatch';
+}
+
+export interface BackupDurationIssue {
+  partId: string;
+  measureNumber: number;
+  backupIndex: number;
+  expected: number;
+  actual: number;
+  reason: 'missing-backup' | 'duration-mismatch';
+}
+
+export function staffDurationSums(measure: ParsedMeasure): Map<number, number> {
+  const sums = new Map<number, number>();
+  for (const note of measure.notes) {
+    if (note.isChord) continue;
+    const staff = note.staff ?? 1;
+    sums.set(staff, (sums.get(staff) ?? 0) + (Number.isFinite(note.duration) ? note.duration : 0));
+  }
+  return sums;
+}
+
+/**
+ * Verify each declared staff in a multi-staff part has a complete duration stream.
+ * For implicit pickup measures, every staff must have the same shortened duration;
+ * full measures must equal the inherited time-signature expectation.
+ */
+export function checkStaffDurationSums(score: ParsedScore): StaffDurationIssue[] {
+  const issues: StaffDurationIssue[] = [];
+  for (const part of score.parts) {
+    for (const measure of part.measures) {
+      if (measure.staves <= 1) continue;
+      const expected = expectedMeasureDivisions(measure);
+      if (!Number.isFinite(expected)) continue;
+
+      for (const note of measure.notes) {
+        if (note.staff === undefined) {
+          issues.push({
+            partId: part.id,
+            measureNumber: measure.number,
+            staffNumber: 0,
+            expected,
+            actual: note.duration,
+            reason: 'missing-staff-tag',
+          });
+        }
+      }
+
+      const sums = staffDurationSums(measure);
+      const pickupExpected = measure.isImplicit ? Math.max(...sums.values()) : expected;
+      for (let staffNumber = 1; staffNumber <= measure.staves; staffNumber++) {
+        const actual = sums.get(staffNumber) ?? 0;
+        if (actual === 0) {
+          issues.push({
+            partId: part.id,
+            measureNumber: measure.number,
+            staffNumber,
+            expected: pickupExpected,
+            actual,
+            reason: 'missing-staff',
+          });
+        } else if (measure.isImplicit && actual !== pickupExpected) {
+          issues.push({
+            partId: part.id,
+            measureNumber: measure.number,
+            staffNumber,
+            expected: pickupExpected,
+            actual,
+            reason: 'pickup-mismatch',
+          });
+        } else if (!measure.isImplicit && actual !== expected) {
+          issues.push({
+            partId: part.id,
+            measureNumber: measure.number,
+            staffNumber,
+            expected,
+            actual,
+            reason: 'duration-mismatch',
+          });
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+/**
+ * Verify MusicXML <backup> elements rewind the cursor by the preceding staff's
+ * duration in a single-part multi-staff export.
+ */
+export function checkBackupDurations(score: ParsedScore): BackupDurationIssue[] {
+  const issues: BackupDurationIssue[] = [];
+  for (const part of score.parts) {
+    for (const measure of part.measures) {
+      if (measure.staves <= 1) continue;
+      const sums = staffDurationSums(measure);
+      for (let staffNumber = 2; staffNumber <= measure.staves; staffNumber++) {
+        const backupIndex = staffNumber - 2;
+        const expected = sums.get(staffNumber - 1) ?? 0;
+        const actual = measure.backups[backupIndex]?.duration;
+        if (actual === undefined) {
+          issues.push({
+            partId: part.id,
+            measureNumber: measure.number,
+            backupIndex,
+            expected,
+            actual: 0,
+            reason: 'missing-backup',
+          });
+        } else if (actual !== expected) {
+          issues.push({
+            partId: part.id,
+            measureNumber: measure.number,
+            backupIndex,
+            expected,
+            actual,
+            reason: 'duration-mismatch',
+          });
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+export interface TupletNotationIssue {
+  partId: string;
+  measureNumber: number;
+  noteIndex: number;
+  reason: 'tuplet-notation-on-chord-member';
+}
+
+/**
+ * MusicXML encodes tuplet brackets on the time-advancing note stream. A secondary
+ * <chord/> note may carry <time-modification>, but it must not duplicate bracket
+ * <notations><tuplet/> that belong to the primary note.
+ */
+export function checkTupletNotationPlacement(score: ParsedScore): TupletNotationIssue[] {
+  const issues: TupletNotationIssue[] = [];
+  for (const part of score.parts) {
+    for (const measure of part.measures) {
+      measure.notes.forEach((note, index) => {
+        if (note.isChord && note.tupletNotationTypes.length > 0) {
+          issues.push({
+            partId: part.id,
+            measureNumber: measure.number,
+            noteIndex: index,
+            reason: 'tuplet-notation-on-chord-member',
+          });
+        }
+      });
+    }
+  }
+  return issues;
+}
+
+const NOTE_CHILD_ORDER = [
+  'chord',
+  'pitch',
+  'rest',
+  'duration',
+  'tie',
+  'type',
+  'dot',
+  'accidental',
+  'time-modification',
+  'staff',
+  'notations',
+] as const;
+
+const NOTE_CHILD_RANK = new Map<string, number>(NOTE_CHILD_ORDER.map((tag, index) => [tag, index]));
+
+type OrderedNode = Record<string, unknown>;
+
+function tagName(node: OrderedNode): string | undefined {
+  return Object.keys(node).find((key) => key !== ':@' && key !== '#text');
+}
+
+function collectOrderedElements(
+  nodes: unknown,
+  wanted: string,
+  out: unknown[][] = []
+): unknown[][] {
+  if (!Array.isArray(nodes)) return out;
+  for (const node of nodes) {
+    if (!node || typeof node !== 'object') continue;
+    const record = node as OrderedNode;
+    const tag = tagName(record);
+    if (!tag) continue;
+    const children = record[tag];
+    if (tag === wanted && Array.isArray(children)) {
+      out.push(children);
+    }
+    collectOrderedElements(children, wanted, out);
+  }
+  return out;
+}
+
+export interface NoteChildOrderIssue {
+  noteIndex: number;
+  previous: string;
+  current: string;
+}
+
+export function checkNoteChildOrder(xml: string): NoteChildOrderIssue[] {
+  const ordered = orderedParser.parse(xml);
+  const noteChildren = collectOrderedElements(ordered, 'note');
+  const issues: NoteChildOrderIssue[] = [];
+
+  noteChildren.forEach((children, noteIndex) => {
+    let lastRank = -1;
+    let lastTag = '';
+    for (const child of children) {
+      if (!child || typeof child !== 'object') continue;
+      const tag = tagName(child as OrderedNode);
+      if (!tag) continue;
+      const rank = NOTE_CHILD_RANK.get(tag);
+      if (rank === undefined) continue;
+      if (rank < lastRank) {
+        issues.push({ noteIndex, previous: lastTag, current: tag });
+        return;
+      }
+      lastRank = rank;
+      lastTag = tag;
+    }
+  });
+
+  return issues;
+}
+
+export interface FullMeasureRestIssue {
+  partId: string;
+  measureNumber: number;
+  staffNumber: number;
+  reason: 'missing-measure-rest-attribute';
+}
+
+export function checkFullMeasureRests(score: ParsedScore): FullMeasureRestIssue[] {
+  const issues: FullMeasureRestIssue[] = [];
+  for (const part of score.parts) {
+    for (const measure of part.measures) {
+      const expected = measure.isImplicit ? NaN : expectedMeasureDivisions(measure);
+      for (const note of measure.notes) {
+        if (
+          note.isRest &&
+          !note.isChord &&
+          Number.isFinite(expected) &&
+          note.duration === expected &&
+          !note.restMeasure
+        ) {
+          issues.push({
+            partId: part.id,
+            measureNumber: measure.number,
+            staffNumber: note.staff ?? 1,
+            reason: 'missing-measure-rest-attribute',
+          });
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+export interface MusicXmlValidationIssue {
+  category:
+    | 'duration'
+    | 'staff-duration'
+    | 'backup'
+    | 'tuplet-notation'
+    | 'note-order'
+    | 'full-measure-rest';
+  message: string;
+  detail:
+    | DurationSumIssue
+    | StaffDurationIssue
+    | BackupDurationIssue
+    | TupletNotationIssue
+    | NoteChildOrderIssue
+    | FullMeasureRestIssue;
+}
+
+export function validateMusicXmlStructure(xml: string): MusicXmlValidationIssue[] {
+  const score = parseMusicXml(xml);
+  const singleStaffDurationIssues = checkDurationSums(score).filter((issue) => {
+    const measure = score.parts
+      .find((part) => part.id === issue.partId)
+      ?.measures.find((m) => m.number === issue.measureNumber);
+    return !measure?.isImplicit && (measure?.staves ?? 1) <= 1;
+  });
+
+  return [
+    ...singleStaffDurationIssues.map((detail) => ({
+      category: 'duration' as const,
+      message: `measure ${detail.measureNumber} duration sum ${detail.actual} != ${detail.expected}`,
+      detail,
+    })),
+    ...checkStaffDurationSums(score).map((detail) => ({
+      category: 'staff-duration' as const,
+      message: `measure ${detail.measureNumber} staff ${detail.staffNumber} ${detail.reason}`,
+      detail,
+    })),
+    ...checkBackupDurations(score).map((detail) => ({
+      category: 'backup' as const,
+      message: `measure ${detail.measureNumber} backup ${detail.backupIndex} ${detail.reason}`,
+      detail,
+    })),
+    ...checkTupletNotationPlacement(score).map((detail) => ({
+      category: 'tuplet-notation' as const,
+      message: `measure ${detail.measureNumber} chord note has tuplet notation`,
+      detail,
+    })),
+    ...checkNoteChildOrder(xml).map((detail) => ({
+      category: 'note-order' as const,
+      message: `note ${detail.noteIndex} has ${detail.current} after ${detail.previous}`,
+      detail,
+    })),
+    ...checkFullMeasureRests(score).map((detail) => ({
+      category: 'full-measure-rest' as const,
+      message: `measure ${detail.measureNumber} staff ${detail.staffNumber} lacks rest measure attribute`,
+      detail,
+    })),
+  ];
 }

--- a/src/__tests__/fixtures/musicXmlStructure.ts
+++ b/src/__tests__/fixtures/musicXmlStructure.ts
@@ -9,11 +9,13 @@
  * The headline invariant is the DURATION-SUM check: within a measure, the sum of
  * <duration> across time-advancing notes (i.e. excluding <chord/> members, which sound
  * simultaneously with the previous note) must equal divisions * beats. This is exactly
- * the invariant that exposes the live tuplet-truncation bug
- * (musicXmlExporter.ts: `Math.floor((dur * ratio[1]) / ratio[0])`), where three triplet
- * eighths export durations summing to 15 instead of 16 at divisions=16. The substring
- * tests in the existing exporter suite are GREEN on that corrupt output; this helper is
- * not, because it computes a real arithmetic invariant rather than matching text.
+ * the invariant that exposed the tuplet-truncation bug the exporter formerly had
+ * (musicXmlExporter.ts once did `Math.floor((dur * ratio[1]) / ratio[0])`, so three
+ * triplet eighths summed to 15 instead of 16 at divisions=16). That bug is now fixed —
+ * <divisions> is content-derived (LCM of tuplet denominators) so durations are exact
+ * integers — and this helper is the regression guard: the substring tests in the existing
+ * exporter suite were GREEN even on the old corrupt output; this one computes a real
+ * arithmetic invariant rather than matching text, so it would catch a relapse.
  */
 
 import { XMLParser } from 'fast-xml-parser';

--- a/src/__tests__/fixtures/musicXmlValidation.README.md
+++ b/src/__tests__/fixtures/musicXmlValidation.README.md
@@ -6,10 +6,10 @@ parse-based structural oracle), with full XSD validation deferred to Phase 2.
 
 ## Files
 
-- **`musicxml-partwise.xsd`** — a focused, self-contained MusicXML 4.0 *partwise*
+- **`musicxml-partwise.xsd`** — a focused, self-contained MusicXML 4.0 _partwise_
   schema fixture. It is **not** the full official multi-file XSD; it captures the
   structural skeleton RiffScore's exporter emits (`score-partwise > part > measure >
-  note > {pitch|rest|chord} + duration + type`). It documents the real `octave` (single
+note > {pitch|rest|chord} + duration + type`). It documents the real `octave` (single
   digit 0–9) and `divisions`/`duration` (positive integer) constraints.
 - **`musicXmlStructure.ts`** — the Phase-1 oracle that runs **today** under Jest using
   `fast-xml-parser`. It parses an exported document and exposes:
@@ -19,12 +19,26 @@ parse-based structural oracle), with full XSD validation deferred to Phase 2.
   - `expectedMeasureDivisions(measure)` — `divisions * beats * (4 / beatType)`.
   - `checkDurationSums(score)` — returns the list of measures whose duration sum does
     not equal the time-signature expectation (empty == valid).
+  - `checkStaffDurationSums(score)` — for multi-staff single-part exports, verifies
+    every declared staff has a complete duration stream, while allowing implicit
+    pickups when all staves share the same shortened duration.
+  - `checkBackupDurations(score)` — verifies each `<backup>` rewinds by the preceding
+    staff's duration in grand-staff exports.
+  - `checkNoteChildOrder(xml)` — validates the MusicXML `<note>` child-order subset
+    RiffScore emits (`pitch/rest`, `duration`, `tie`, `type`, `dot`, `accidental`,
+    `time-modification`, `staff`, `notations`).
+  - `checkTupletNotationPlacement(score)` — rejects tuplet bracket notations duplicated
+    onto secondary `<chord/>` notes.
+  - `checkFullMeasureRests(score)` — requires full-bar rests to be encoded as
+    `<rest measure="yes"/>`.
   - `allDurationsIntegral(score)` — every `<duration>` is a positive integer.
+  - `validateMusicXmlStructure(xml)` — aggregates the checks above into one
+    exporter-facing validation gate.
 
 ## Why parse-based first, XSD second
 
-XSD validation proves *well-formedness against a grammar*; it does **not** prove
-*musical sense*. The live exporter bug
+XSD validation proves _well-formedness against a grammar_; it does **not** prove
+_musical sense_. The live exporter bug
 (`musicXmlExporter.ts`: `Math.floor((dur * ratio[1]) / ratio[0])`) emits triplet-eighth
 durations that sum to 15 instead of 16 at `divisions=16` — that output is still
 schema-valid but musically corrupt. The **duration-sum invariant** catches it; an XSD
@@ -41,9 +55,11 @@ in Phase 1; XSD validation is an additional well-formedness gate for Phase 2.
 To add hard XSD validation, choose one:
 
 1. **`xmllint` (system binary, CI image):**
+
    ```sh
    xmllint --noout --schema src/__tests__/fixtures/musicxml-partwise.xsd exported.musicxml
    ```
+
    Or swap in the full official MusicXML 4.0 XSD bundle.
 
 2. **`libxmljs2` (npm, in-process):**
@@ -58,4 +74,4 @@ To add hard XSD validation, choose one:
    `package.json`, and CI must build native deps.
 
 Until then, import `musicXmlStructure.ts` directly in exporter tests for the
-content-level invariants.
+content-level invariants and the M3 structural validation gate.

--- a/src/__tests__/fixtures/musicXmlValidation.README.md
+++ b/src/__tests__/fixtures/musicXmlValidation.README.md
@@ -38,17 +38,18 @@ note > {pitch|rest|chord} + duration + type`). It documents the real `octave` (s
 ## Why parse-based first, XSD second
 
 XSD validation proves _well-formedness against a grammar_; it does **not** prove
-_musical sense_. The live exporter bug
-(`musicXmlExporter.ts`: `Math.floor((dur * ratio[1]) / ratio[0])`) emits triplet-eighth
-durations that sum to 15 instead of 16 at `divisions=16` — that output is still
-schema-valid but musically corrupt. The **duration-sum invariant** catches it; an XSD
-alone would not. So the parse-based content oracle is the higher-value check and ships
-in Phase 1; XSD validation is an additional well-formedness gate for Phase 2.
+_musical sense_. The exporter bug this oracle was built to catch
+(`musicXmlExporter.ts` formerly did `Math.floor((dur * ratio[1]) / ratio[0])`) emitted
+triplet-eighth durations summing to 15 instead of 16 at `divisions=16` — schema-valid but
+musically corrupt. The **duration-sum invariant** catches it; an XSD alone would not. So
+the parse-based content oracle is the higher-value check and ships in Phase 1; XSD
+validation is an additional well-formedness gate for Phase 2.
 
 > Note (from the verification strategy): `divisions=16` **cannot** represent triplet
-> eighths as integers. The real fix pairs a larger `divisions` value
-> (e.g. `LCM(16, present tuplet denominators)`) with removing the `Math.floor`. The
-> duration-sum test will correctly stay red until both are fixed.
+> eighths as integers. The fix — now landed (alpha.16) — pairs a content-derived
+> `divisions` value (`LCM` of the present tuplet denominators) with removing the
+> `Math.floor`, so durations are exact integers. The duration-sum test is now **green**
+> and stands as the regression guard against that class of corruption returning.
 
 ## Phase-2 wiring (deferred)
 

--- a/src/__tests__/property/musicXmlStructure.self.test.ts
+++ b/src/__tests__/property/musicXmlStructure.self.test.ts
@@ -15,6 +15,12 @@ import {
   expectedMeasureDivisions,
   checkDurationSums,
   allDurationsIntegral,
+  checkBackupDurations,
+  checkFullMeasureRests,
+  checkNoteChildOrder,
+  checkStaffDurationSums,
+  checkTupletNotationPlacement,
+  validateMusicXmlStructure,
 } from '../fixtures/musicXmlStructure';
 
 // A correct 4/4 measure at divisions=16: four quarter notes (16 each) sum to 64.
@@ -99,6 +105,98 @@ const BUGGY_TRIPLET_4_4 = `<?xml version="1.0"?>
   </part>
 </score-partwise>`;
 
+const GRAND_STAFF_4_4 = `<?xml version="1.0"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>16</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <staves>2</staves>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>64</duration><type>whole</type><staff>1</staff></note>
+      <backup><duration>64</duration></backup>
+      <note><pitch><step>C</step><octave>3</octave></pitch><duration>64</duration><type>whole</type><staff>2</staff></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+const GRAND_STAFF_PICKUP = `<?xml version="1.0"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="0" implicit="yes">
+      <attributes>
+        <divisions>16</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <staves>2</staves>
+      </attributes>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>16</duration><type>quarter</type><staff>1</staff></note>
+      <backup><duration>16</duration></backup>
+      <note><pitch><step>G</step><octave>2</octave></pitch><duration>16</duration><type>quarter</type><staff>2</staff></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+const MISSING_SECOND_STAFF = GRAND_STAFF_4_4.replace(
+  '<backup><duration>64</duration></backup>\n      <note><pitch><step>C</step><octave>3</octave></pitch><duration>64</duration><type>whole</type><staff>2</staff></note>',
+  ''
+).replace(
+  '<note><pitch><step>C</step><octave>4</octave></pitch><duration>64</duration><type>whole</type><staff>1</staff></note>',
+  '<note><pitch><step>C</step><octave>4</octave></pitch><duration>64</duration><type>whole</type></note>'
+);
+
+const BAD_BACKUP = GRAND_STAFF_4_4.replace(
+  '<backup><duration>64</duration></backup>',
+  '<backup><duration>32</duration></backup>'
+);
+
+const BAD_NOTE_ORDER = `<?xml version="1.0"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>16</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><type>quarter</type><duration>16</duration></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+const CHORD_WITH_DUPLICATE_TUPLET_NOTATION = `<?xml version="1.0"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>48</divisions>
+        <time><beats>1</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>16</duration><type>eighth</type><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification><notations><tuplet type="start" bracket="yes"/></notations></note>
+      <note><chord/><pitch><step>E</step><octave>4</octave></pitch><duration>16</duration><type>eighth</type><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification><notations><tuplet type="start" bracket="yes"/></notations></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>16</duration><type>eighth</type><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>16</duration><type>eighth</type><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification><notations><tuplet type="stop"/></notations></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+const FULL_MEASURE_REST = `<?xml version="1.0"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>16</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note><rest measure="yes"/><duration>64</duration><type>whole</type></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
 describe('musicXmlStructure helper self-test', () => {
   it('parses parts, measures and notes with correct flags', () => {
     const score = parseMusicXml(CHORD_3_4);
@@ -154,5 +252,66 @@ describe('musicXmlStructure helper self-test', () => {
     expect(allDurationsIntegral(parseMusicXml(CORRECT_4_4))).toBe(true);
     const fractional = CORRECT_4_4.replace('<duration>16</duration>', '<duration>5.33</duration>');
     expect(allDurationsIntegral(parseMusicXml(fractional))).toBe(false);
+  });
+
+  it('inherits time/staves and validates each grand-staff duration stream separately', () => {
+    const score = parseMusicXml(GRAND_STAFF_4_4);
+    expect(score.parts[0].measures[0].staves).toBe(2);
+    expect(checkStaffDurationSums(score)).toEqual([]);
+    expect(validateMusicXmlStructure(GRAND_STAFF_4_4)).toEqual([]);
+  });
+
+  it('allows implicit grand-staff pickups when every staff has the same shortened duration', () => {
+    expect(checkStaffDurationSums(parseMusicXml(GRAND_STAFF_PICKUP))).toEqual([]);
+    expect(validateMusicXmlStructure(GRAND_STAFF_PICKUP)).toEqual([]);
+  });
+
+  it('flags missing staff tags and missing declared staff streams', () => {
+    const issues = checkStaffDurationSums(parseMusicXml(MISSING_SECOND_STAFF));
+    expect(issues.map((i) => i.reason)).toEqual(
+      expect.arrayContaining(['missing-staff-tag', 'missing-staff'])
+    );
+  });
+
+  it('checks <backup> durations against the preceding staff stream', () => {
+    expect(checkBackupDurations(parseMusicXml(GRAND_STAFF_4_4))).toEqual([]);
+    expect(checkBackupDurations(parseMusicXml(BAD_BACKUP))).toEqual([
+      expect.objectContaining({ expected: 64, actual: 32, reason: 'duration-mismatch' }),
+    ]);
+  });
+
+  it('validates the subset of MusicXML <note> DTD child ordering RiffScore emits', () => {
+    expect(checkNoteChildOrder(CORRECT_4_4)).toEqual([]);
+    expect(checkNoteChildOrder(BAD_NOTE_ORDER)).toEqual([
+      expect.objectContaining({ previous: 'type', current: 'duration' }),
+    ]);
+  });
+
+  it('flags tuplet bracket notations duplicated onto secondary <chord/> notes', () => {
+    expect(
+      checkTupletNotationPlacement(parseMusicXml(CHORD_WITH_DUPLICATE_TUPLET_NOTATION))
+    ).toEqual([
+      expect.objectContaining({ noteIndex: 1, reason: 'tuplet-notation-on-chord-member' }),
+    ]);
+  });
+
+  it('requires full-bar rests to use rest measure="yes"', () => {
+    expect(checkFullMeasureRests(parseMusicXml(FULL_MEASURE_REST))).toEqual([]);
+    const plainRest = FULL_MEASURE_REST.replace('<rest measure="yes"/>', '<rest/>');
+    expect(checkFullMeasureRests(parseMusicXml(plainRest))).toEqual([
+      expect.objectContaining({ reason: 'missing-measure-rest-attribute' }),
+    ]);
+  });
+
+  it('aggregates structural validation issues by category', () => {
+    const issues = validateMusicXmlStructure(
+      BAD_NOTE_ORDER.replace(
+        '</measure>',
+        '<note><rest/><duration>40</duration><type>whole</type></note></measure>'
+      )
+    );
+    expect(issues.map((i) => i.category)).toEqual(
+      expect.arrayContaining(['duration', 'note-order'])
+    );
   });
 });

--- a/src/__tests__/tupletFillLiveRender.test.tsx
+++ b/src/__tests__/tupletFillLiveRender.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+/* eslint-disable testing-library/no-node-access */
 /**
  * Regression (user bug, round 2): filling a reserved tuplet slot on a MOUNTED editor must render
  * the note. Unlike extractFacts (fresh mount of the final score), this dispatches delete+fill on a

--- a/src/__tests__/visual/tieRender.test.tsx
+++ b/src/__tests__/visual/tieRender.test.tsx
@@ -19,6 +19,7 @@ jest.mock('@/engines/toneEngine', () => ({
 import { renderScore } from '../helpers/visual';
 import { createDefaultScore, Score, ScoreEvent } from '@/types';
 import { TIE } from '@/constants';
+import { calculateMeasureLayout } from '@/engines/layout';
 
 const q = (id: string, pitch: string | null, tied = false): ScoreEvent =>
   pitch === null
@@ -90,5 +91,45 @@ describe('tie rendering', () => {
     } finally {
       unmount();
     }
+  });
+});
+
+describe('tie layout stays on the notehead when a system is justified (#249, stretch ≠ 1.0)', () => {
+  // The renderer draws ties (Staff.tsx renderTies) and noteheads (Measure → useMeasureLayout)
+  // from the SAME measure layout: both share measureStartXs, so tie-X == notehead-X reduces
+  // to the two paths agreeing on `eventPositions`. In the unstretched path both read the
+  // centralized legacyLayout. In the justified (stretch ≠ 1.0) path the Measure recomputes via
+  // useMeasureLayout(events, …, forcedEventPositions = legacyLayout.eventPositions, stretch, key)
+  // and renderTies recomputes via calculateMeasureLayout(events, …, undefined, stretch, key).
+  // calculateMeasureLayout's forcedEventPositions is QUANT-keyed while legacyLayout.eventPositions
+  // is ID-keyed, so today the forced map is a no-op in BOTH paths and they coincide. This pins
+  // that contract: if a future change makes forced positions effective for the Measure without
+  // also threading them into renderTies, this test fails — a tie would drift off its notehead.
+  const events: ScoreEvent[] = [
+    { id: 'a', duration: 'quarter', dotted: false, notes: [{ id: 'an', pitch: 'F#4', tied: true }] },
+    { id: 'b', duration: 'quarter', dotted: false, notes: [{ id: 'bn', pitch: 'F#4' }] },
+    { id: 'c', duration: 'quarter', dotted: false, notes: [{ id: 'cn', pitch: 'G4' }] },
+    { id: 'd', duration: 'quarter', dotted: false, notes: [{ id: 'dn', pitch: 'A4' }] },
+  ];
+  const clef = 'treble';
+  const key = 'G'; // non-C: accidental width is in play for the F#4s
+  const stretch = 1.5;
+
+  it('the Measure layout and the tie layout produce identical event positions when stretched', () => {
+    // What Staff.tsx forwards to the Measure as forcedEventPositions (id-keyed).
+    const legacyPositions = calculateMeasureLayout(events, undefined, clef, false, undefined, 1.0, key)
+      .eventPositions;
+
+    const measurePath = calculateMeasureLayout(events, undefined, clef, false, legacyPositions, stretch, key)
+      .eventPositions;
+    const tiePath = calculateMeasureLayout(events, undefined, clef, false, undefined, stretch, key)
+      .eventPositions;
+
+    expect(tiePath).toEqual(measurePath);
+
+    // Sanity: the stretch is non-trivial, so the equality above is not vacuous.
+    const unstretched = calculateMeasureLayout(events, undefined, clef, false, undefined, 1.0, key)
+      .eventPositions;
+    expect(tiePath).not.toEqual(unstretched);
   });
 });

--- a/src/__tests__/visual/tieRender.test.tsx
+++ b/src/__tests__/visual/tieRender.test.tsx
@@ -18,16 +18,18 @@ jest.mock('@/engines/toneEngine', () => ({
 
 import { renderScore } from '../helpers/visual';
 import { createDefaultScore, Score, ScoreEvent } from '@/types';
+import { TIE } from '@/constants';
 
 const q = (id: string, pitch: string | null, tied = false): ScoreEvent =>
   pitch === null
     ? { id, duration: 'quarter', dotted: false, isRest: true, notes: [{ id: `${id}n`, pitch: null, isRest: true }] }
     : { id, duration: 'quarter', dotted: false, notes: [{ id: `${id}n`, pitch, tied }] };
 
-const scoreOf = (events: ScoreEvent[]): Score => {
+const scoreOf = (events: ScoreEvent[], keySignature = 'C'): Score => {
   const s = createDefaultScore();
   s.timeSignature = '4/4';
-  s.staves = [{ ...s.staves[0], measures: [{ id: 'm0', events }] }];
+  s.keySignature = keySignature;
+  s.staves = [{ ...s.staves[0], keySignature, measures: [{ id: 'm0', events }] }];
   return s;
 };
 
@@ -36,6 +38,20 @@ const tieCount = (score: Score): number => {
   const n = container.querySelectorAll('.riff-Tie').length;
   unmount();
   return n;
+};
+
+const firstMoveX = (path: Element): number => {
+  const d = path.getAttribute('d') ?? '';
+  const match = d.match(/M\s+(-?\d+(?:\.\d+)?)/);
+  if (!match) throw new Error(`Unable to parse tie path: ${d}`);
+  return Number(match[1]);
+};
+
+const translateX = (group: Element): number => {
+  const transform = group.getAttribute('transform') ?? '';
+  const match = transform.match(/translate\(\s*(-?\d+(?:\.\d+)?)/);
+  if (!match) throw new Error(`Unable to parse transform: ${transform}`);
+  return Number(match[1]);
 };
 
 describe('tie rendering', () => {
@@ -49,5 +65,30 @@ describe('tie rendering', () => {
 
   it('draws NO tie when the tied note is the last in the score', () => {
     expect(tieCount(scoreOf([q('a', 'C4'), q('b', 'C4'), q('c', 'C4'), q('d', 'C4', true)]))).toBe(0);
+  });
+
+  it('anchors tie X to the rendered notehead under a non-C key signature (#249)', () => {
+    const score = scoreOf(
+      [q('a', 'F#4', true), q('b', 'F#4'), q('c', 'G4'), q('d', 'A4')],
+      'G'
+    );
+    const { canvas, unmount } = renderScore(score);
+    try {
+      const tie = canvas.querySelector('.riff-Tie');
+      const chord = canvas.querySelector('[data-testid="chord-a"]');
+      const notehead = chord?.querySelector('.NoteHead');
+      const measure = chord?.closest('.Measure');
+
+      expect(tie).not.toBeNull();
+      expect(chord).not.toBeNull();
+      expect(notehead).not.toBeNull();
+      expect(measure).not.toBeNull();
+
+      const expectedStartX =
+        translateX(measure!) + Number(notehead!.getAttribute('x')) + 10 + TIE.START_GAP;
+      expect(firstMoveX(tie!)).toBeCloseTo(expectedStartX, 2);
+    } finally {
+      unmount();
+    }
   });
 });

--- a/src/componentTypes.ts
+++ b/src/componentTypes.ts
@@ -12,6 +12,7 @@ export interface LayoutConfig {
   baseY: number; // Base Y for the system (e.g. CONFIG.baseY)
   clef: string; // Current Clef ('treble', 'bass')
   keySignature: string; // Current Key Sig
+  timeSignature: string; // Current Time Sig
   staffIndex: number; // Which staff this measure belongs to
   verticalOffset: number; // Vertical offset for hit detection mapping
   mouseLimits?: { min: number; max: number }; // Optional clamping range

--- a/src/components/Canvas/Beam.tsx
+++ b/src/components/Canvas/Beam.tsx
@@ -13,10 +13,10 @@ import { BEAMING } from '@/constants';
  * @param direction - Stem direction (affects secondary beam offset)
  */
 const Beam = ({ beam, color }) => {
-  const { startX, endX, startY, endY, type, direction } = beam;
+  const { startX, endX, startY, endY, type, direction, segments } = beam;
   const { theme } = useTheme();
 
-  const renderBeam = (y1, y2, key, thickness = 5) => {
+  const renderBeam = (y1, y2, key, thickness = 5, x1 = startX, x2 = endX) => {
     // To get vertical ends, we draw a polygon.
     // Top-Left: (startX, y1)
     // Top-Right: (endX, y2)
@@ -31,16 +31,32 @@ const Beam = ({ beam, color }) => {
     const halfWidth = thickness / 2;
 
     const points = [
-      `${startX},${y1 - halfWidth}`,
-      `${endX},${y2 - halfWidth}`,
-      `${endX},${y2 + halfWidth}`,
-      `${startX},${y1 + halfWidth}`,
+      `${x1},${y1 - halfWidth}`,
+      `${x2},${y2 - halfWidth}`,
+      `${x2},${y2 + halfWidth}`,
+      `${x1},${y1 + halfWidth}`,
     ].join(' ');
 
     return <polygon key={key} points={points} fill={color || theme.score.note} />;
   };
 
   const paths = [];
+
+  if (segments?.length) {
+    segments.forEach((segment, index) => {
+      paths.push(
+        renderBeam(
+          segment.startY,
+          segment.endY,
+          `segment-${index}`,
+          BEAMING.THICKNESS,
+          segment.startX,
+          segment.endX
+        )
+      );
+    });
+    return <g className="beam-group">{paths}</g>;
+  }
 
   // Primary Beam (Outermost) - Standard Thickness
   paths.push(renderBeam(startY, endY, 'primary', BEAMING.THICKNESS));

--- a/src/components/Canvas/Beam.tsx
+++ b/src/components/Canvas/Beam.tsx
@@ -1,6 +1,11 @@
-// @ts-nocheck
 import { useTheme } from '@/context/ThemeContext';
 import { BEAMING } from '@/constants';
+import type { BeamGroup } from '@/engines/layout/types';
+
+interface BeamProps {
+  beam: BeamGroup;
+  color?: string;
+}
 
 /**
  * Renders a beam connecting multiple notes.
@@ -12,11 +17,18 @@ import { BEAMING } from '@/constants';
  * @param type - Duration type (determines number of beams)
  * @param direction - Stem direction (affects secondary beam offset)
  */
-const Beam = ({ beam, color }) => {
+const Beam = ({ beam, color }: BeamProps) => {
   const { startX, endX, startY, endY, type, direction, segments } = beam;
   const { theme } = useTheme();
 
-  const renderBeam = (y1, y2, key, thickness = 5, x1 = startX, x2 = endX) => {
+  const renderBeam = (
+    y1: number,
+    y2: number,
+    key: string,
+    thickness = 5,
+    x1 = startX,
+    x2 = endX
+  ) => {
     // To get vertical ends, we draw a polygon.
     // Top-Left: (startX, y1)
     // Top-Right: (endX, y2)
@@ -40,7 +52,7 @@ const Beam = ({ beam, color }) => {
     return <polygon key={key} points={points} fill={color || theme.score.note} />;
   };
 
-  const paths = [];
+  const paths: ReturnType<typeof renderBeam>[] = [];
 
   if (segments?.length) {
     segments.forEach((segment, index) => {
@@ -65,7 +77,7 @@ const Beam = ({ beam, color }) => {
   const beamSpacing = BEAMING.SPACING;
   const innerBeamThickness = BEAMING.THICKNESS;
 
-  const addBeam = (index) => {
+  const addBeam = (index: number) => {
     const offset = direction === 'up' ? index * beamSpacing : -(index * beamSpacing);
     paths.push(renderBeam(startY + offset, endY + offset, `beam-${index}`, innerBeamThickness));
   };

--- a/src/components/Canvas/Measure.tsx
+++ b/src/components/Canvas/Measure.tsx
@@ -92,7 +92,7 @@ const Measure: React.FC<MeasureProps> = ({
 }) => {
   const { theme } = useTheme();
   const { events } = measureData;
-  const { scale, baseY, clef, keySignature } = layout;
+  const { scale, baseY, clef, keySignature, timeSignature } = layout;
   const {
     selection,
     previewNote,
@@ -110,7 +110,8 @@ const Measure: React.FC<MeasureProps> = ({
     forcedEventPositions,
     forcedWidth,
     stretchFactor,
-    keySignature
+    keySignature,
+    timeSignature
   );
 
   // Extract layout data

--- a/src/components/Canvas/ScoreCanvas.tsx
+++ b/src/components/Canvas/ScoreCanvas.tsx
@@ -18,7 +18,7 @@ import { MeasureNumber } from './MeasureNumber';
 import { MetadataTrack } from './MetadataTrack';
 import { PageFooter } from './PageFooter';
 import { useMetadataTrack } from '@/hooks/layout/useMetadataTrack';
-import { getActiveStaff, Staff as StaffType, DEFAULT_CHORD_DISPLAY } from '@/types';
+import { getActiveStaff, Staff as StaffType, DEFAULT_CHORD_DISPLAY, Page } from '@/types';
 import { HitZone } from '@/engines/layout/types';
 import { useScoreContext } from '@/context/ScoreContext';
 import { useScoreInteraction } from '@/hooks/interaction';
@@ -261,7 +261,7 @@ const ScoreCanvas: React.FC<ScoreCanvasProps> = ({
 
   // Helper to compute page-relative measure positions for chord track
   const getPageMeasurePositions = useCallback(
-    (page: (typeof pageLayout.pages)[0]) => {
+    (page: Page) => {
       const measureWidths = calculateAllMeasureWidths(score, 1.0);
       const staffScale = pageLayout.staffScale;
       const positions: Array<{ x: number; width: number; quant: number }> = [];

--- a/src/components/Canvas/Staff.tsx
+++ b/src/components/Canvas/Staff.tsx
@@ -168,6 +168,7 @@ const Staff: React.FC<StaffProps> = ({
           baseY: CONFIG.baseY,
           clef,
           keySignature,
+          timeSignature,
           staffIndex,
           verticalOffset: 0, // Staff is at 0 relative to itself (positioned by parent)
           mouseLimits, // Pass clamping limits
@@ -180,17 +181,34 @@ const Staff: React.FC<StaffProps> = ({
   // Render ties between notes
   const renderTies = () => {
     const ties: React.ReactElement[] = [];
-    // Use same preamble calculation as main measure rendering
-    const { measuresX: tieStartX } = calculateSystemPreamble(keySignature, { isFirstSystem });
-
-    let currentMeasureX = tieStartX;
-
     const allNotes: TieNote[] = [];
 
     measures.forEach((measure, mIndex: number) => {
-      const layout = calculateMeasureLayout(measure.events, undefined, clef, false);
+      const actualMeasureIndex = measureIndices?.[mIndex] ?? mIndex;
+      const layout =
+        stretchFactor !== 1.0
+          ? calculateMeasureLayout(
+              measure.events,
+              undefined,
+              clef,
+              measure.isPickup ?? false,
+              undefined,
+              stretchFactor,
+              keySignature
+            )
+          : (staffLayout?.measures[actualMeasureIndex]?.legacyLayout ??
+            calculateMeasureLayout(
+              measure.events,
+              undefined,
+              clef,
+              measure.isPickup ?? false,
+              undefined,
+              1.0,
+              keySignature
+            ));
+      const measureX = measureStartXs[mIndex];
       measure.events.forEach((event, eIndex: number) => {
-        const eventX = currentMeasureX + layout.eventPositions[event.id];
+        const eventX = measureX + layout.eventPositions[event.id];
         event.notes.forEach((note, nIndex: number) => {
           // Skip rest notes (which have null pitch) - they can't have ties
           if (note.pitch === null) return;
@@ -207,7 +225,6 @@ const Staff: React.FC<StaffProps> = ({
           });
         });
       });
-      currentMeasureX += layout.totalWidth;
     });
 
     allNotes.forEach((note) => {

--- a/src/engines/layout/beaming.ts
+++ b/src/engines/layout/beaming.ts
@@ -136,8 +136,21 @@ export const calculateBeamingGroups = (
       finalizeGroup();
     }
 
+    const eventEndQuant = currentQuant + durationQuants;
+    // Do not start the deferred tuplet-beaming work here: tuplets can carry
+    // fractional beat positions on the current quant grid, so the #245
+    // no-dependency fix only splits plain flagged events that overrun a beat.
+    const crossesPlainBeatBoundary =
+      !event.tuplet &&
+      Math.floor((eventEndQuant - 1e-9) / beatQuants) !== Math.floor(currentQuant / beatQuants);
+    if (crossesPlainBeatBoundary) {
+      finalizeGroup();
+      currentQuant = eventEndQuant;
+      return;
+    }
+
     currentGroup.push(event);
-    currentQuant += durationQuants;
+    currentQuant = eventEndQuant;
   });
 
   finalizeGroup();

--- a/src/engines/layout/beaming.ts
+++ b/src/engines/layout/beaming.ts
@@ -1,5 +1,5 @@
 import { ScoreEvent } from '@/types';
-import { BeamGroup } from './types';
+import { BeamGroup, BeamSegment } from './types';
 import { getNoteDuration } from '@/utils/core';
 import { getOffsetForPitch, calculateChordLayout, getStemOffset } from './positioning';
 import { CONFIG } from '@/config';
@@ -72,6 +72,15 @@ export const getBeamBeatQuants = (timeSignature = '4/4'): number => {
   return denominatorUnitQuants;
 };
 
+const BEAM_LEVELS: Record<string, number> = {
+  eighth: 1,
+  sixteenth: 2,
+  thirtysecond: 3,
+  sixtyfourth: 4,
+};
+
+const beamLevelForDuration = (duration: string): number => BEAM_LEVELS[duration] ?? 0;
+
 /**
  * Groups events into beaming groups based on musical rules (beats, syncopation).
  * All calculations use CONFIG.baseY - staff positioning is handled by SVG transforms.
@@ -90,7 +99,6 @@ export const calculateBeamingGroups = (
 ): BeamGroup[] => {
   const groups: BeamGroup[] = [];
   let currentGroup: ScoreEvent[] = [];
-  let currentType: string | null = null;
 
   // Helper to finalize a group
   const finalizeGroup = () => {
@@ -98,7 +106,6 @@ export const calculateBeamingGroups = (
       groups.push(processBeamGroup(currentGroup, eventPositions, clef));
     }
     currentGroup = [];
-    currentType = null;
   };
 
   let currentQuant = 0;
@@ -109,24 +116,16 @@ export const calculateBeamingGroups = (
   const beatQuants = getBeamBeatQuants(timeSignature);
 
   events.forEach((event: ScoreEvent) => {
-    const type = event.duration;
-    const isFlagged = ['eighth', 'sixteenth', 'thirtysecond', 'sixtyfourth'].includes(type);
-    const durationQuants = getNoteDuration(type, event.dotted, event.tuplet);
+    const beamLevel = beamLevelForDuration(event.duration);
+    const durationQuants = getNoteDuration(event.duration, event.dotted, event.tuplet);
 
-    // Break beam if:
-    // 1. Not a flagged note
-    // 2. Dotted note (simplify for now - standard beaming breaks on dots usually unless configured)
-    // 3. Type changes (e.g. 8th to 16th - simple engines often break here, complex ones don't)
-    // 4. Rest
-
-    if (!isFlagged || event.isRest) {
+    // Break beams on rests and unbeamable durations. Mixed flagged values stay in
+    // one beat-level group; secondary/partial beam segments encode the shorter
+    // values instead of splitting the primary beam (#245).
+    if (beamLevel === 0 || event.isRest) {
       finalizeGroup();
       currentQuant += durationQuants;
       return;
-    }
-
-    if (currentType && currentType !== type) {
-      finalizeGroup();
     }
 
     // Break the beam at every beat boundary so beams never span across beats.
@@ -138,7 +137,6 @@ export const calculateBeamingGroups = (
     }
 
     currentGroup.push(event);
-    currentType = type;
     currentQuant += durationQuants;
   });
 
@@ -157,8 +155,6 @@ const processBeamGroup = (
   eventPositions: Record<string, number>,
   clef: string
 ): BeamGroup => {
-  const startEvent = groupEvents[0];
-
   // Determine minimum stem length based on the note type with the most beams in the group
   // 32nd notes need longer stems to accommodate 3 beams, 64th for 4 beams
   let minStemLength = STEM_BEAMED_LENGTHS.default;
@@ -287,6 +283,74 @@ const processBeamGroup = (
     }
   }
 
+  const lineYAt = (x: number): number => {
+    const finalSlope = (endBeamY - startBeamY) / (endX - startX);
+    const finalIntercept = startBeamY - finalSlope * startX;
+    return finalSlope * x + finalIntercept;
+  };
+
+  const highestBeamLevel = Math.max(
+    ...groupEvents.map((event) => beamLevelForDuration(event.duration))
+  );
+  const segmentFor = (level: number, start: number, end: number): BeamSegment => {
+    const offset =
+      direction === 'up' ? (level - 1) * BEAMING.SPACING : -(level - 1) * BEAMING.SPACING;
+    return {
+      level,
+      startX: start,
+      endX: end,
+      startY: lineYAt(start) + offset,
+      endY: lineYAt(end) + offset,
+    };
+  };
+
+  const stemXs = noteData.map((d) => d.eventX);
+  const segments: BeamSegment[] = [segmentFor(1, startX, endX)];
+
+  for (let level = 2; level <= highestBeamLevel; level++) {
+    let runStart = -1;
+
+    const flushRun = (runEnd: number) => {
+      if (runStart === -1) return;
+
+      if (runEnd > runStart) {
+        segments.push(
+          segmentFor(
+            level,
+            stemXs[runStart] - BEAMING.EXTENSION_PX,
+            stemXs[runEnd] + BEAMING.EXTENSION_PX
+          )
+        );
+      } else {
+        const stemX = stemXs[runStart];
+        const prevX = stemXs[runStart - 1];
+        const nextX = stemXs[runStart + 1];
+        const towardNext = nextX !== undefined;
+        const neighborX = towardNext ? nextX : prevX;
+        const gap = neighborX === undefined ? 24 : Math.abs(neighborX - stemX);
+        const length = Math.min(14, Math.max(8, gap * 0.45));
+        const beamletStart = towardNext ? stemX : stemX - length;
+        const beamletEnd = towardNext ? stemX + length : stemX;
+        segments.push(segmentFor(level, beamletStart, beamletEnd));
+      }
+
+      runStart = -1;
+    };
+
+    groupEvents.forEach((event, index) => {
+      if (beamLevelForDuration(event.duration) >= level) {
+        if (runStart === -1) runStart = index;
+      } else {
+        flushRun(index - 1);
+      }
+    });
+    flushRun(groupEvents.length - 1);
+  }
+
+  const groupType =
+    groupEvents.find((event) => beamLevelForDuration(event.duration) === highestBeamLevel)
+      ?.duration ?? groupEvents[0].duration;
+
   return {
     ids: groupEvents.map((e) => e.id),
     startX,
@@ -294,6 +358,7 @@ const processBeamGroup = (
     startY: startBeamY,
     endY: endBeamY,
     direction,
-    type: startEvent.duration,
+    type: groupType,
+    segments,
   };
 };

--- a/src/engines/layout/types.ts
+++ b/src/engines/layout/types.ts
@@ -57,6 +57,16 @@ export interface BeamGroup {
   endY: number;
   direction: 'up' | 'down';
   type: string;
+  segments?: BeamSegment[];
+}
+
+export interface BeamSegment {
+  /** 1 = primary eighth beam, 2 = sixteenth beam, etc. */
+  level: number;
+  startX: number;
+  endX: number;
+  startY: number;
+  endY: number;
 }
 
 export interface TupletBracketGroup {

--- a/src/engines/layout/types.ts
+++ b/src/engines/layout/types.ts
@@ -57,7 +57,7 @@ export interface BeamGroup {
   endY: number;
   direction: 'up' | 'down';
   type: string;
-  segments?: BeamSegment[];
+  segments: BeamSegment[];
 }
 
 export interface BeamSegment {

--- a/src/exporters/abcExporter.ts
+++ b/src/exporters/abcExporter.ts
@@ -16,6 +16,8 @@ import { hasTieTarget } from '@/utils/ties';
 import { Note as TonalNote } from 'tonal';
 import { canonicalizeKeySignature } from '@/utils/keyResolution';
 import { MeasureAccidentalState, keySignatureAltForLetter } from '@/utils/accidentalContext';
+import { quantizeChordAnchor } from '@/services/chord/ChordQuants';
+import { sumQuants } from '@/utils/tuplet';
 
 /**
  * Convert an internal key string ('C', 'G', 'Bb', 'F#', 'Em', 'Dm') to a valid
@@ -86,9 +88,29 @@ const buildChordLookup = (
     if (!lookup.has(chord.measure)) {
       lookup.set(chord.measure, new Map<number, string>());
     }
-    lookup.get(chord.measure)!.set(chord.quant, chord.symbol);
+    lookup.get(chord.measure)!.set(quantizeChordAnchor(chord.quant), chord.symbol);
   }
   return lookup;
+};
+
+const gcd = (a: number, b: number): number => (b === 0 ? Math.abs(a) : gcd(b, a % b));
+
+const meterForQuants = (quants: number): string | null => {
+  if (!Number.isFinite(quants) || quants <= 0) return null;
+
+  // Internal quants use 64 per whole note. Reduce the occupied pickup span to
+  // the ABC M:n/d meter fraction; e.g. 16 quants -> M:1/4, 24 -> M:3/8.
+  const numerator = Math.round(quants);
+  if (Math.abs(numerator - quants) > 1e-6) return null;
+  const divisor = gcd(numerator, NOTE_TYPES.whole.duration);
+  return `${numerator / divisor}/${NOTE_TYPES.whole.duration / divisor}`;
+};
+
+const pickupMeterForMeasure = (measure: Measure): string | null => {
+  if (!measure.isPickup) return null;
+  const { quants, partialTuplet } = sumQuants(measure.events);
+  if (partialTuplet) return null;
+  return meterForQuants(quants);
 };
 
 // ABC notation pitch mapping - Algorithmic
@@ -189,10 +211,20 @@ export const generateABC = (score: Score, bpm: number): string => {
     staff.measures.forEach((measure: Measure, measureIndex: number) => {
       // Track local quant position within the measure
       let localQuant = 0;
+      const isPickup = measure.isPickup === true && measureIndex === 0;
+      const pickupMeter = isPickup ? pickupMeterForMeasure(measure) : null;
+      const shouldRestoreMeter =
+        measureIndex === 1 && staff.measures[0]?.isPickup === true && pickupMeterForMeasure(staff.measures[0]) != null;
 
       // Measure-local accidental ledger: accidentals persist to the barline and
       // are cancelled with '='; reset for every new measure.
       const accidentalState = new MeasureAccidentalState();
+
+      if (pickupMeter) {
+        abc += `[M:${pickupMeter}]`;
+      } else if (shouldRestoreMeter) {
+        abc += `[M:${timeSig}]`;
+      }
 
       // Pad an under-full bar with trailing rests for valid output (#242); never mutates state.
       padMeasureForExport(measure, getMeasureCapacity(timeSig)).forEach((event: ScoreEvent, eventIndex: number) => {
@@ -236,7 +268,7 @@ export const generateABC = (score: Score, bpm: number): string => {
         // Add chord annotation if present at this position (first staff only)
         if (includeChords) {
           const measureChords = chordLookup.get(measureIndex);
-          const chordSymbol = measureChords?.get(localQuant);
+          const chordSymbol = measureChords?.get(quantizeChordAnchor(localQuant));
           if (chordSymbol) {
             prefix += `"${chordSymbol}"`;
           }

--- a/src/exporters/musicXmlExporter.ts
+++ b/src/exporters/musicXmlExporter.ts
@@ -63,6 +63,7 @@ const collectTupletDivisors = (score: Score): number[] => {
   const staves = score.staves || [getActiveStaff(score)];
   for (const staff of staves) {
     for (const measure of staff.measures) {
+      if (!measure) continue;
       for (const event of measure.events) {
         if (event.tuplet) {
           const actual = event.tuplet.ratio[0];
@@ -185,7 +186,6 @@ const exportMetadataToXML = (metadata: ScoreMetadata): string => {
  */
 const CHORD_KIND_MAP: Record<string, string> = {
   '': 'major',
-  '7sus4': 'suspended-fourth',
   maj13: 'major-13th',
   maj11: 'major-11th',
   maj9: 'major-ninth',
@@ -256,9 +256,11 @@ const parseChordForMusicXML = (
   // Find the matching kind (try longer suffixes first)
   const sortedKinds = Object.keys(CHORD_KIND_MAP).sort((a, b) => b.length - a.length);
   let kind = 'major';
+  let matchedSuffix = '';
   for (const suffix of sortedKinds) {
     if (suffix && qualityKey.startsWith(suffix)) {
       kind = CHORD_KIND_MAP[suffix];
+      matchedSuffix = suffix;
       break;
     }
   }
@@ -268,13 +270,16 @@ const parseChordForMusicXML = (
   }
 
   const degrees: MusicXmlDegree[] = [];
-  for (const match of qualityKey.matchAll(/add(9|11|13)|([#b])([59]|11|13)/g)) {
+  const residualQuality = qualityKey.slice(matchedSuffix.length);
+  for (const match of residualQuality.matchAll(/add(9|11|13)|sus([24])|([#b])([59]|11|13)/g)) {
     if (match[1]) {
       degrees.push({ value: Number(match[1]), alter: 0, type: 'add' });
+    } else if (match[2]) {
+      degrees.push({ value: Number(match[2]), alter: 0, type: 'add' });
     } else {
       degrees.push({
-        value: Number(match[3]),
-        alter: match[2] === '#' ? 1 : -1,
+        value: Number(match[4]),
+        alter: match[3] === '#' ? 1 : -1,
         type: 'alter',
       });
     }
@@ -406,6 +411,7 @@ const renderEvent = (
   measures: Measure[],
   measureIndex: number,
   eventIndex: number,
+  measureSpanQuants: number,
   staffNumber?: number
 ): string => {
   let xml = '';
@@ -422,8 +428,7 @@ const renderEvent = (
   let timeModTag = '';
   if (event.tuplet) {
     const [actual, normal] = event.tuplet.ratio;
-    const normalType =
-      NOTE_TYPES[event.tuplet.baseDuration ?? event.duration]?.xmlType ?? xmlType;
+    const normalType = NOTE_TYPES[event.tuplet.baseDuration ?? event.duration]?.xmlType ?? xmlType;
     timeModTag = `
       <time-modification>
         <actual-notes>${actual}</actual-notes>
@@ -443,10 +448,13 @@ const renderEvent = (
         restTupletTag = '<tuplet type="stop"/>';
     }
     const restNotations = restTupletTag ? `\n      <notations>${restTupletTag}</notations>` : '';
+    const isMeasureRest =
+      !event.tuplet && duration === measureSpanDivisions(measureSpanQuants, divisions);
+    const restTag = isMeasureRest ? '<rest measure="yes"/>' : '<rest/>';
     // REST — DTD order: <rest/> <duration> <type> <dot> <time-modification> <staff> <notations>
     xml += `
     <note>
-      <rest/>
+      ${restTag}
       <duration>${duration}</duration>
       <type>${xmlType}</type>
       ${event.dotted ? '<dot/>' : ''}
@@ -582,11 +590,17 @@ const renderEvent = (
 const measureDivisionSum = (events: ScoreEvent[], divisions: number): number =>
   events.reduce((sum, event) => sum + eventDivisions(event, divisions), 0);
 
-const measureCapacityDivisions = (measureCapacity: number, divisions: number): number =>
-  Math.round((measureCapacity / BASE_DIVISIONS_PER_QUARTER) * divisions);
+const measureQuantSum = (events: ScoreEvent[]): number =>
+  events.reduce(
+    (sum, event) => sum + getNoteDuration(event.duration, event.dotted, event.tuplet),
+    0
+  );
+
+const measureSpanDivisions = (measureSpanQuants: number, divisions: number): number =>
+  Math.round((measureSpanQuants / BASE_DIVISIONS_PER_QUARTER) * divisions);
 
 const renderFullMeasureRest = (
-  measureCapacity: number,
+  measureSpanQuants: number,
   divisions: number,
   staffNumber?: number
 ): string => {
@@ -594,7 +608,7 @@ const renderFullMeasureRest = (
   return `
     <note>
       <rest measure="yes"/>
-      <duration>${measureCapacityDivisions(measureCapacity, divisions)}</duration>${staffTag}
+      <duration>${measureSpanDivisions(measureSpanQuants, divisions)}</duration>${staffTag}
     </note>`;
 };
 
@@ -626,6 +640,13 @@ export const generateMusicXML = (score: Score): string => {
   const hasPickup = staves[0]?.measures[0]?.isPickup === true;
   const measureNumberFor = (mIndex: number): number => (hasPickup ? mIndex : mIndex + 1);
   const isImplicit = (mIndex: number): boolean => hasPickup && mIndex === 0;
+  const measureSpanQuantsFor = (mIndex: number): number => {
+    if (!isImplicit(mIndex)) return measureCapacity;
+
+    const firstMeasure = staves[0]?.measures[mIndex];
+    const pickupSpan = firstMeasure ? measureQuantSum(firstMeasure.events) : 0;
+    return pickupSpan > 0 ? pickupSpan : measureCapacity;
+  };
 
   // Use metadata with fallback to defaults, then fall back to legacy title field
   const metadata: ScoreMetadata = score.metadata ?? {
@@ -697,6 +718,7 @@ export const generateMusicXML = (score: Score): string => {
   for (let mIndex = 0; mIndex < measureCount; mIndex++) {
     const number = measureNumberFor(mIndex);
     const implicitAttr = isImplicit(mIndex) ? ' implicit="yes"' : '';
+    const measureSpanQuants = measureSpanQuantsFor(mIndex);
     xml += `\n    <measure number="${number}"${implicitAttr}>`;
 
     // Attributes appear on the first measure (pickup or first full measure).
@@ -742,7 +764,10 @@ export const generateMusicXML = (score: Score): string => {
         // the same way so the <backup> duration matches the padded measure (grand-staff align).
         const prevMeasure = staves[staffIndex - 1].measures[mIndex];
         const prevEvents = prevMeasure ? padMeasureForExport(prevMeasure, measureCapacity) : [];
-        const backup = measureDivisionSum(prevEvents, divisions);
+        const backup =
+          prevMeasure && prevEvents.length > 0
+            ? measureDivisionSum(prevEvents, divisions)
+            : measureSpanDivisions(measureSpanQuants, divisions);
         if (backup > 0) {
           xml += `
     <backup>
@@ -760,8 +785,8 @@ export const generateMusicXML = (score: Score): string => {
       const activeTies = activeTiesByStaff[staffIndex];
       const staffNumber = isGrandStaff ? staffIndex + 1 : undefined;
 
-      if ((!measure || measure.events.length === 0) && !measure?.isPickup) {
-        xml += renderFullMeasureRest(measureCapacity, divisions, staffNumber);
+      if (!measure || measure.events.length === 0) {
+        xml += renderFullMeasureRest(measureSpanQuants, divisions, staffNumber);
         return;
       }
 
@@ -787,6 +812,7 @@ export const generateMusicXML = (score: Score): string => {
           staff.measures,
           mIndex,
           eventIndex,
+          measureSpanQuants,
           staffNumber
         );
 

--- a/src/exporters/musicXmlExporter.ts
+++ b/src/exporters/musicXmlExporter.ts
@@ -15,6 +15,7 @@ import { findTieTarget } from '@/utils/ties';
 import { Note } from 'tonal';
 import { canonicalizeKeySignature } from '@/utils/keyResolution';
 import { MeasureAccidentalState, keySignatureAltForLetter } from '@/utils/accidentalContext';
+import { quantizeChordAnchor } from '@/services/chord/ChordQuants';
 
 /** Maps an alteration to its MusicXML <accidental> glyph name. 0 is natural. */
 const xmlAccidentalName = (alt: number): string => {
@@ -184,17 +185,38 @@ const exportMetadataToXML = (metadata: ScoreMetadata): string => {
  */
 const CHORD_KIND_MAP: Record<string, string> = {
   '': 'major',
-  m: 'minor',
-  '7': 'dominant',
-  maj7: 'major-seventh',
-  m7: 'minor-seventh',
-  dim: 'diminished',
-  aug: 'augmented',
+  '7sus4': 'suspended-fourth',
+  maj13: 'major-13th',
+  maj11: 'major-11th',
+  maj9: 'major-ninth',
   dim7: 'diminished-seventh',
   m7b5: 'half-diminished',
+  maj7: 'major-seventh',
+  m13: 'minor-13th',
+  m11: 'minor-11th',
+  m9: 'minor-ninth',
+  m7: 'minor-seventh',
+  m6: 'minor-sixth',
   sus4: 'suspended-fourth',
   sus2: 'suspended-second',
+  maj: 'major',
+  dim: 'diminished',
+  aug: 'augmented',
+  '13': 'dominant-13th',
+  '11': 'dominant-11th',
+  '9': 'dominant-ninth',
+  '7': 'dominant',
+  '6': 'major-sixth',
+  m: 'minor',
 };
+
+type MusicXmlDegreeType = 'add' | 'alter' | 'subtract';
+
+interface MusicXmlDegree {
+  value: number;
+  alter: number;
+  type: MusicXmlDegreeType;
+}
 
 /**
  * Parse a chord symbol into MusicXML harmony components.
@@ -202,7 +224,13 @@ const CHORD_KIND_MAP: Record<string, string> = {
  */
 const parseChordForMusicXML = (
   symbol: string
-): { root: string; alter: number; kind: string; bass?: { step: string; alter: number } } | null => {
+): {
+  root: string;
+  alter: number;
+  kind: string;
+  bass?: { step: string; alter: number };
+  degrees: MusicXmlDegree[];
+} | null => {
   // Handle slash chords (e.g., "C/E")
   let chordPart = symbol;
   let bassPart: string | null = null;
@@ -223,19 +251,33 @@ const parseChordForMusicXML = (
 
   // Extract quality/kind from the rest of the symbol
   const qualityPart = chordPart.slice(rootMatch[0].length);
+  const qualityKey = qualityPart.replace(/^M/, 'maj');
 
   // Find the matching kind (try longer suffixes first)
   const sortedKinds = Object.keys(CHORD_KIND_MAP).sort((a, b) => b.length - a.length);
   let kind = 'major';
   for (const suffix of sortedKinds) {
-    if (suffix && qualityPart.startsWith(suffix)) {
+    if (suffix && qualityKey.startsWith(suffix)) {
       kind = CHORD_KIND_MAP[suffix];
       break;
     }
   }
   // If no suffix matched but qualityPart is empty, it's major
-  if (qualityPart === '') {
+  if (qualityKey === '') {
     kind = 'major';
+  }
+
+  const degrees: MusicXmlDegree[] = [];
+  for (const match of qualityKey.matchAll(/add(9|11|13)|([#b])([59]|11|13)/g)) {
+    if (match[1]) {
+      degrees.push({ value: Number(match[1]), alter: 0, type: 'add' });
+    } else {
+      degrees.push({
+        value: Number(match[3]),
+        alter: match[2] === '#' ? 1 : -1,
+        type: 'alter',
+      });
+    }
   }
 
   const result: {
@@ -243,10 +285,12 @@ const parseChordForMusicXML = (
     alter: number;
     kind: string;
     bass?: { step: string; alter: number };
+    degrees: MusicXmlDegree[];
   } = {
     root: rootStep,
     alter: rootAlter,
     kind,
+    degrees,
   };
 
   // Parse bass note if present
@@ -292,6 +336,15 @@ const generateHarmonyElement = (chord: ChordSymbol): string => {
             : ''
         }
       </bass>`;
+  }
+
+  for (const degree of parsed.degrees) {
+    xml += `
+      <degree>
+        <degree-value>${degree.value}</degree-value>
+        <degree-alter>${degree.alter}</degree-alter>
+        <degree-type>${degree.type}</degree-type>
+      </degree>`;
   }
 
   xml += `
@@ -470,7 +523,7 @@ const renderEvent = (
 
     // Tuplet bracket notations (start/stop) — separate from time-modification.
     let tupletNotations = '';
-    if (event.tuplet) {
+    if (!isChord && event.tuplet) {
       if (event.tuplet.position === 0) {
         const tupTag = '<tuplet type="start" bracket="yes"/>';
         if (tiedNotations) {
@@ -529,6 +582,22 @@ const renderEvent = (
 const measureDivisionSum = (events: ScoreEvent[], divisions: number): number =>
   events.reduce((sum, event) => sum + eventDivisions(event, divisions), 0);
 
+const measureCapacityDivisions = (measureCapacity: number, divisions: number): number =>
+  Math.round((measureCapacity / BASE_DIVISIONS_PER_QUARTER) * divisions);
+
+const renderFullMeasureRest = (
+  measureCapacity: number,
+  divisions: number,
+  staffNumber?: number
+): string => {
+  const staffTag = staffNumber === undefined ? '' : `\n      <staff>${staffNumber}</staff>`;
+  return `
+    <note>
+      <rest measure="yes"/>
+      <duration>${measureCapacityDivisions(measureCapacity, divisions)}</duration>${staffTag}
+    </note>`;
+};
+
 export const generateMusicXML = (score: Score): string => {
   const staves = score.staves || [getActiveStaff(score)];
   const timeSig = score.timeSignature || '4/4';
@@ -569,10 +638,11 @@ export const generateMusicXML = (score: Score): string => {
   const chordMap = new Map<number, Map<number, ChordSymbol>>();
   if (score.chordTrack) {
     for (const chord of score.chordTrack) {
+      const quant = quantizeChordAnchor(chord.quant);
       if (!chordMap.has(chord.measure)) {
         chordMap.set(chord.measure, new Map<number, ChordSymbol>());
       }
-      chordMap.get(chord.measure)!.set(chord.quant, chord);
+      chordMap.get(chord.measure)!.set(quant, chord);
     }
   }
 
@@ -636,6 +706,7 @@ export const generateMusicXML = (score: Score): string => {
       <divisions>${divisions}</divisions>
       <key>
         <fifths>${fifths}</fifths>
+        <mode>${keySigData?.mode ?? 'major'}</mode>
       </key>
       <time>
         <beats>${timeSig.split('/')[0]}</beats>
@@ -689,6 +760,11 @@ export const generateMusicXML = (score: Score): string => {
       const activeTies = activeTiesByStaff[staffIndex];
       const staffNumber = isGrandStaff ? staffIndex + 1 : undefined;
 
+      if ((!measure || measure.events.length === 0) && !measure?.isPickup) {
+        xml += renderFullMeasureRest(measureCapacity, divisions, staffNumber);
+        return;
+      }
+
       // Track local quant position within measure (for chord placement, top staff only).
       let localQuant = 0;
 
@@ -696,7 +772,7 @@ export const generateMusicXML = (score: Score): string => {
         // Insert harmony element before note if chord exists at this position
         // (chords annotate the top staff's timeline only).
         if (staffIndex === 0) {
-          const chord = chordMap.get(mIndex)?.get(localQuant);
+          const chord = chordMap.get(mIndex)?.get(quantizeChordAnchor(localQuant));
           if (chord) {
             xml += generateHarmonyElement(chord);
           }

--- a/src/services/chord/ChordQuants.ts
+++ b/src/services/chord/ChordQuants.ts
@@ -17,7 +17,7 @@ import { getMeasureCapacity } from '@/constants';
  * anchor grid and the position probe both go through this so a chord just after a tuplet isn't
  * dropped as orphaned over a sub-nanoquant mismatch.
  */
-const quantizeAnchor = (q: number): number => Math.round(q * 1000) / 1000;
+export const quantizeChordAnchor = (q: number): number => Math.round(q * 1000) / 1000;
 
 // ============================================================================
 // MEASURE CAPACITY (TILING)
@@ -84,7 +84,7 @@ export const getValidChordQuants = (score: Score): Map<number, Set<number>> => {
         // All events (notes and notated rests) are valid chord anchor points — but NOT a
         // reserved tuplet slot (#242): it draws nothing, so a chord must not float over it.
         // It still advances localQuant (it occupies its footprint).
-        if (!isReservedSlot(event)) measureQuants.add(quantizeAnchor(localQuant));
+        if (!isReservedSlot(event)) measureQuants.add(quantizeChordAnchor(localQuant));
         localQuant += getNoteDuration(event.duration, event.dotted, event.tuplet);
       }
     }
@@ -102,7 +102,7 @@ export const isValidChordPosition = (
   quant: number
 ): boolean => {
   const measureQuants = validPositions.get(measure);
-  return measureQuants?.has(quantizeAnchor(quant)) ?? false;
+  return measureQuants?.has(quantizeChordAnchor(quant)) ?? false;
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

This lands the M3 export and engraving fidelity milestone on top of `dev`.

- Export fidelity: quantized MusicXML/ABC chord anchors, MusicXML key `<mode>`, richer harmony kind/degree export, primary-note-only tuplet bracket notations, full-measure rests for empty grand-staff staves, ABC pickup meter annotations, quintuplet ratios, and final barlines.
- Engraving fidelity: key-aware/stretched cross-measure tie layout, direct `Measure` fallback layout using the real time signature, and mixed-value primary/secondary/partial beam segments for dotted/16th rhythms.
- Validation: deterministic MusicXML structural checks for staff duration streams, backups, note child order, tuplet notation placement, and full-measure rests, including real exporter smoke coverage.
- Docs: changelog and roadmap now mark scoped M3 complete while keeping full official MusicXML 4.0 XSD CI as follow-up hardening.

## QA

Isolated lane QA:

- Export lane: focused exporter tests passed; full serial Jest passed (`164` suites / `3077` tests); typecheck passed; build passed; lint reported only the pre-existing warnings seen on all lanes.
- Engraving lane: focused layout/visual tests passed; full serial Jest passed (`165` suites / `3060` tests); typecheck passed; build passed; lint reported only the same pre-existing warnings.
- Validation lane: focused validation/export tests passed; full serial Jest passed (`165` suites / `3068` tests); typecheck passed; build passed; lint reported only the same pre-existing warnings.

Integration QA:

- `git diff --check origin/dev...HEAD` passed.
- `npm run typecheck` passed.
- `npm run lint` passed with two pre-existing warnings:
  - `src/__tests__/tupletFillLiveRender.test.tsx`: unused eslint-disable directive.
  - `src/components/Canvas/ScoreCanvas.tsx`: missing `pageLayout` hook dependency.
- `npm test -- --ci --runInBand --silent` passed (`166` suites / `3091` tests / `85` snapshots).
- `npm run build` passed.
- Structured visual regression passed (`src/__tests__/visual/visualRegression.test.tsx`, `102` tests / `85` snapshots).
- `npm run visual:pixel` was attempted locally; it built the gallery and captured browser output, but macOS generated `*-chromium-darwin.png` actuals because the committed baselines are Linux CI baselines. Generated local actuals and `test-results` were cleaned up; pixel comparison should run in Linux CI.
